### PR TITLE
feat(widget): Step 5 フローティングウィジェットUI実装

### DIFF
--- a/__tests__/unit/widget.test.js
+++ b/__tests__/unit/widget.test.js
@@ -1,0 +1,392 @@
+'use strict';
+
+const { createWidget, STATES } = require('../../ui/widget');
+
+describe('createWidget', () => {
+  let widget;
+
+  beforeEach(() => {
+    // 既存ウィジェットをクリーンアップ
+    const existing = document.getElementById('vfa-widget');
+    if (existing) existing.remove();
+    widget = createWidget();
+  });
+
+  afterEach(() => {
+    widget.destroy();
+  });
+
+  // ──────────────────────────────────────
+  // DOM生成
+  // ──────────────────────────────────────
+  describe('DOM生成', () => {
+    test('document.body に #vfa-widget を追加する', () => {
+      const el = document.getElementById('vfa-widget');
+      expect(el).not.toBeNull();
+      expect(document.body.contains(el)).toBe(true);
+    });
+
+    test('.vfa-status 要素を持つ', () => {
+      const el = document.getElementById('vfa-widget');
+      expect(el.querySelector('.vfa-status')).not.toBeNull();
+    });
+
+    test('.vfa-transcript 要素を持つ', () => {
+      const el = document.getElementById('vfa-widget');
+      expect(el.querySelector('.vfa-transcript')).not.toBeNull();
+    });
+
+    test('.vfa-message 要素を持つ', () => {
+      const el = document.getElementById('vfa-widget');
+      expect(el.querySelector('.vfa-message')).not.toBeNull();
+    });
+
+    test('.vfa-confirm 要素と はい/いいえ ボタンを持つ', () => {
+      const el = document.getElementById('vfa-widget');
+      expect(el.querySelector('.vfa-confirm')).not.toBeNull();
+      expect(el.querySelector('.vfa-btn-yes')).not.toBeNull();
+      expect(el.querySelector('.vfa-btn-no')).not.toBeNull();
+    });
+
+    test('role="status" 属性を持つ（アクセシビリティ）', () => {
+      const el = document.getElementById('vfa-widget');
+      expect(el.getAttribute('role')).toBe('status');
+    });
+
+    test('innerHTML を使用しない（XSS防止）', () => {
+      const el = document.getElementById('vfa-widget');
+      widget.setState(STATES.ERROR, { message: '<script>alert(1)</script>' });
+      const messageEl = el.querySelector('.vfa-message');
+      // textContent でセットされていれば innerHTML はエスケープされる
+      expect(messageEl.textContent).toBe('<script>alert(1)</script>');
+      expect(messageEl.innerHTML).toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
+    });
+  });
+
+  // ──────────────────────────────────────
+  // 初期状態
+  // ──────────────────────────────────────
+  describe('初期状態', () => {
+    test('getState() は idle を返す', () => {
+      expect(widget.getState()).toBe(STATES.IDLE);
+    });
+
+    test('ウィジェットは非表示', () => {
+      const el = document.getElementById('vfa-widget');
+      expect(el.style.display).toBe('none');
+    });
+
+    test('data-state 属性が idle', () => {
+      const el = document.getElementById('vfa-widget');
+      expect(el.getAttribute('data-state')).toBe('idle');
+    });
+  });
+
+  // ──────────────────────────────────────
+  // listening 状態
+  // ──────────────────────────────────────
+  describe('setState(listening)', () => {
+    beforeEach(() => {
+      widget.setState(STATES.LISTENING);
+    });
+
+    test('ウィジェットを表示する', () => {
+      const el = document.getElementById('vfa-widget');
+      expect(el.style.display).toBe('block');
+    });
+
+    test('ステータスに "リスニング中..." を表示する', () => {
+      const el = document.getElementById('vfa-widget');
+      expect(el.querySelector('.vfa-status').textContent).toBe('リスニング中...');
+    });
+
+    test('確認ボタンを非表示にする', () => {
+      const el = document.getElementById('vfa-widget');
+      expect(el.querySelector('.vfa-confirm').style.display).toBe('none');
+    });
+
+    test('getState() は listening を返す', () => {
+      expect(widget.getState()).toBe(STATES.LISTENING);
+    });
+
+    test('data-state 属性が listening', () => {
+      const el = document.getElementById('vfa-widget');
+      expect(el.getAttribute('data-state')).toBe('listening');
+    });
+  });
+
+  // ──────────────────────────────────────
+  // processing 状態
+  // ──────────────────────────────────────
+  describe('setState(processing)', () => {
+    test('"処理中..." ステータスでウィジェットを表示する', () => {
+      widget.setState(STATES.PROCESSING);
+      const el = document.getElementById('vfa-widget');
+      expect(el.style.display).toBe('block');
+      expect(el.querySelector('.vfa-status').textContent).toBe('処理中...');
+    });
+
+    test('transcript オプションがあれば transcript 要素にセットする', () => {
+      widget.setState(STATES.PROCESSING, { transcript: 'テスト発話' });
+      const el = document.getElementById('vfa-widget');
+      expect(el.querySelector('.vfa-transcript').textContent).toBe('テスト発話');
+    });
+
+    test('transcript オプションなしでは transcript を変更しない', () => {
+      widget.setState(STATES.LISTENING);
+      widget.setTranscript('事前テキスト');
+      widget.setState(STATES.PROCESSING);
+      const el = document.getElementById('vfa-widget');
+      // transcript は変えずに保持
+      expect(el.querySelector('.vfa-transcript').textContent).toBe('事前テキスト');
+    });
+
+    test('getState() は processing を返す', () => {
+      widget.setState(STATES.PROCESSING);
+      expect(widget.getState()).toBe(STATES.PROCESSING);
+    });
+  });
+
+  // ──────────────────────────────────────
+  // confirm 状態
+  // ──────────────────────────────────────
+  describe('setState(confirm)', () => {
+    let onConfirm;
+
+    beforeEach(() => {
+      onConfirm = jest.fn();
+      widget.setState(STATES.CONFIRM, {
+        message: '田中商事の金額を500万円に変更します。よろしいですか？',
+        transcript: '金額を500万に変更して',
+        onConfirm,
+      });
+    });
+
+    test('ウィジェットを表示する', () => {
+      const el = document.getElementById('vfa-widget');
+      expect(el.style.display).toBe('block');
+    });
+
+    test('ステータスに "確認" を表示する', () => {
+      const el = document.getElementById('vfa-widget');
+      expect(el.querySelector('.vfa-status').textContent).toBe('確認');
+    });
+
+    test('確認ボタンを表示する', () => {
+      const el = document.getElementById('vfa-widget');
+      expect(el.querySelector('.vfa-confirm').style.display).toBe('flex');
+    });
+
+    test('message テキストをセットする', () => {
+      const el = document.getElementById('vfa-widget');
+      expect(el.querySelector('.vfa-message').textContent).toBe(
+        '田中商事の金額を500万円に変更します。よろしいですか？'
+      );
+    });
+
+    test('transcript テキストをセットする', () => {
+      const el = document.getElementById('vfa-widget');
+      expect(el.querySelector('.vfa-transcript').textContent).toBe('金額を500万に変更して');
+    });
+
+    test('はい ボタンクリックで onConfirm(true) を呼ぶ', () => {
+      const el = document.getElementById('vfa-widget');
+      el.querySelector('.vfa-btn-yes').click();
+      expect(onConfirm).toHaveBeenCalledWith(true);
+    });
+
+    test('いいえ ボタンクリックで onConfirm(false) を呼ぶ', () => {
+      const el = document.getElementById('vfa-widget');
+      el.querySelector('.vfa-btn-no').click();
+      expect(onConfirm).toHaveBeenCalledWith(false);
+    });
+
+    test('getState() は confirm を返す', () => {
+      expect(widget.getState()).toBe(STATES.CONFIRM);
+    });
+
+    test('onConfirm なしでもクリックしてもエラーにならない', () => {
+      widget.setState(STATES.CONFIRM, { message: 'テスト' });
+      const el = document.getElementById('vfa-widget');
+      expect(() => el.querySelector('.vfa-btn-yes').click()).not.toThrow();
+    });
+  });
+
+  // ──────────────────────────────────────
+  // success 状態
+  // ──────────────────────────────────────
+  describe('setState(success)', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    test('"完了" ステータスでウィジェットを表示する', () => {
+      widget.setState(STATES.SUCCESS, { message: '田中商事を更新しました' });
+      const el = document.getElementById('vfa-widget');
+      expect(el.style.display).toBe('block');
+      expect(el.querySelector('.vfa-status').textContent).toBe('完了');
+    });
+
+    test('message テキストをセットする', () => {
+      widget.setState(STATES.SUCCESS, { message: '田中商事を更新しました' });
+      const el = document.getElementById('vfa-widget');
+      expect(el.querySelector('.vfa-message').textContent).toBe('田中商事を更新しました');
+    });
+
+    test('デフォルト3000ms 後に idle へ自動遷移する', () => {
+      widget.setState(STATES.SUCCESS, { message: '完了' });
+      const el = document.getElementById('vfa-widget');
+      expect(el.style.display).toBe('block');
+      jest.advanceTimersByTime(3000);
+      expect(el.style.display).toBe('none');
+      expect(widget.getState()).toBe(STATES.IDLE);
+    });
+
+    test('カスタム duration で自動遷移する', () => {
+      widget.setState(STATES.SUCCESS, { message: '完了', duration: 1000 });
+      const el = document.getElementById('vfa-widget');
+      jest.advanceTimersByTime(999);
+      expect(el.style.display).toBe('block');
+      jest.advanceTimersByTime(1);
+      expect(el.style.display).toBe('none');
+    });
+
+    test('getState() は success を返す', () => {
+      widget.setState(STATES.SUCCESS, { message: '完了' });
+      expect(widget.getState()).toBe(STATES.SUCCESS);
+    });
+
+    test('確認ボタンを非表示にする', () => {
+      widget.setState(STATES.SUCCESS, { message: '完了' });
+      const el = document.getElementById('vfa-widget');
+      expect(el.querySelector('.vfa-confirm').style.display).toBe('none');
+    });
+  });
+
+  // ──────────────────────────────────────
+  // error 状態
+  // ──────────────────────────────────────
+  describe('setState(error)', () => {
+    test('"エラー" ステータスでウィジェットを表示する', () => {
+      widget.setState(STATES.ERROR, { message: '見つかりませんでした' });
+      const el = document.getElementById('vfa-widget');
+      expect(el.style.display).toBe('block');
+      expect(el.querySelector('.vfa-status').textContent).toBe('エラー');
+    });
+
+    test('message テキストをセットする', () => {
+      widget.setState(STATES.ERROR, { message: '見つかりませんでした' });
+      const el = document.getElementById('vfa-widget');
+      expect(el.querySelector('.vfa-message').textContent).toBe('見つかりませんでした');
+    });
+
+    test('getState() は error を返す', () => {
+      widget.setState(STATES.ERROR, { message: 'エラー' });
+      expect(widget.getState()).toBe(STATES.ERROR);
+    });
+
+    test('確認ボタンを非表示にする', () => {
+      widget.setState(STATES.ERROR, { message: 'エラー' });
+      const el = document.getElementById('vfa-widget');
+      expect(el.querySelector('.vfa-confirm').style.display).toBe('none');
+    });
+  });
+
+  // ──────────────────────────────────────
+  // idle 状態へ戻る
+  // ──────────────────────────────────────
+  describe('setState(idle)', () => {
+    test('listening からウィジェットを非表示にする', () => {
+      widget.setState(STATES.LISTENING);
+      widget.setState(STATES.IDLE);
+      const el = document.getElementById('vfa-widget');
+      expect(el.style.display).toBe('none');
+    });
+
+    test('status / message / transcript をクリアする', () => {
+      widget.setState(STATES.ERROR, { message: 'エラー' });
+      widget.setState(STATES.IDLE);
+      const el = document.getElementById('vfa-widget');
+      expect(el.querySelector('.vfa-status').textContent).toBe('');
+      expect(el.querySelector('.vfa-message').textContent).toBe('');
+      expect(el.querySelector('.vfa-transcript').textContent).toBe('');
+    });
+
+    test('getState() は idle を返す', () => {
+      widget.setState(STATES.LISTENING);
+      widget.setState(STATES.IDLE);
+      expect(widget.getState()).toBe(STATES.IDLE);
+    });
+  });
+
+  // ──────────────────────────────────────
+  // setTranscript
+  // ──────────────────────────────────────
+  describe('setTranscript', () => {
+    test('transcript テキストを更新する', () => {
+      widget.setState(STATES.LISTENING);
+      widget.setTranscript('田中商事の電話番号を更新して');
+      const el = document.getElementById('vfa-widget');
+      expect(el.querySelector('.vfa-transcript').textContent).toBe('田中商事の電話番号を更新して');
+    });
+
+    test('前の transcript を上書きする', () => {
+      widget.setState(STATES.LISTENING);
+      widget.setTranscript('最初のテキスト');
+      widget.setTranscript('最終テキスト');
+      const el = document.getElementById('vfa-widget');
+      expect(el.querySelector('.vfa-transcript').textContent).toBe('最終テキスト');
+    });
+  });
+
+  // ──────────────────────────────────────
+  // destroy
+  // ──────────────────────────────────────
+  describe('destroy', () => {
+    test('DOM からウィジェットを削除する', () => {
+      widget.destroy();
+      expect(document.getElementById('vfa-widget')).toBeNull();
+      // afterEach で再度 destroy されないよう上書き
+      widget = { destroy: () => {} };
+    });
+  });
+
+  // ──────────────────────────────────────
+  // 状態遷移
+  // ──────────────────────────────────────
+  describe('状態遷移', () => {
+    test('listening → processing へ遷移できる', () => {
+      widget.setState(STATES.LISTENING);
+      widget.setState(STATES.PROCESSING, { transcript: 'テスト' });
+      expect(widget.getState()).toBe(STATES.PROCESSING);
+    });
+
+    test('processing → confirm へ遷移できる', () => {
+      widget.setState(STATES.PROCESSING);
+      widget.setState(STATES.CONFIRM, { message: '確認', onConfirm: jest.fn() });
+      expect(widget.getState()).toBe(STATES.CONFIRM);
+    });
+
+    test('success の自動遷移タイマーを error 遷移でキャンセルする', () => {
+      jest.useFakeTimers();
+      widget.setState(STATES.SUCCESS, { message: '完了', duration: 3000 });
+      widget.setState(STATES.ERROR, { message: 'エラー発生' });
+      jest.advanceTimersByTime(3000);
+      // error のまま → idle に戻らない
+      expect(widget.getState()).toBe(STATES.ERROR);
+      jest.useRealTimers();
+    });
+
+    test('confirm 後に idle へ戻せる', () => {
+      widget.setState(STATES.CONFIRM, { message: '確認', onConfirm: jest.fn() });
+      widget.setState(STATES.IDLE);
+      expect(widget.getState()).toBe(STATES.IDLE);
+      const el = document.getElementById('vfa-widget');
+      expect(el.querySelector('.vfa-confirm').style.display).toBe('none');
+    });
+  });
+});

--- a/content.css
+++ b/content.css
@@ -1,5 +1,4 @@
 /* フローティングウィジェットのスタイル */
-/* Step 5（widget-ui）で詳細を実装 */
 
 #vfa-widget {
   position: fixed;
@@ -9,4 +8,123 @@
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   font-size: 14px;
   pointer-events: auto;
+
+  min-width: 240px;
+  max-width: 360px;
+  background: #ffffff;
+  border-radius: 12px;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15), 0 1px 4px rgba(0, 0, 0, 0.08);
+  padding: 12px 16px;
+  box-sizing: border-box;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+/* ── ステータスライン ── */
+.vfa-status {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  margin-bottom: 4px;
+  color: #6b7280;
+}
+
+/* ── 認識テキスト（リアルタイム表示） ── */
+.vfa-transcript {
+  font-size: 14px;
+  color: #111827;
+  min-height: 20px;
+  word-break: break-all;
+  margin-bottom: 4px;
+}
+
+/* ── メッセージ ── */
+.vfa-message {
+  font-size: 13px;
+  color: #374151;
+  margin-bottom: 4px;
+  line-height: 1.5;
+  word-break: break-all;
+}
+
+/* ── 確認ボタン群 ── */
+.vfa-confirm {
+  display: none;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.vfa-btn {
+  flex: 1;
+  padding: 6px 12px;
+  border: none;
+  border-radius: 8px;
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.vfa-btn-yes {
+  background: #2563eb;
+  color: #ffffff;
+}
+
+.vfa-btn-yes:hover {
+  background: #1d4ed8;
+}
+
+.vfa-btn-no {
+  background: #f3f4f6;
+  color: #374151;
+}
+
+.vfa-btn-no:hover {
+  background: #e5e7eb;
+}
+
+/* ── 状態別スタイル ── */
+
+/* listening: 青系ボーダー */
+#vfa-widget[data-state="listening"] {
+  border-left: 3px solid #2563eb;
+}
+
+#vfa-widget[data-state="listening"] .vfa-status {
+  color: #2563eb;
+}
+
+/* processing: グレーボーダー */
+#vfa-widget[data-state="processing"] {
+  border-left: 3px solid #9ca3af;
+}
+
+#vfa-widget[data-state="processing"] .vfa-status {
+  color: #6b7280;
+}
+
+/* confirm: 黄色ボーダー */
+#vfa-widget[data-state="confirm"] {
+  border-left: 3px solid #d97706;
+}
+
+#vfa-widget[data-state="confirm"] .vfa-status {
+  color: #d97706;
+}
+
+/* success: 緑ボーダー */
+#vfa-widget[data-state="success"] {
+  border-left: 3px solid #16a34a;
+}
+
+#vfa-widget[data-state="success"] .vfa-status {
+  color: #16a34a;
+}
+
+/* error: 赤ボーダー */
+#vfa-widget[data-state="error"] {
+  border-left: 3px solid #dc2626;
+}
+
+#vfa-widget[data-state="error"] .vfa-status {
+  color: #dc2626;
 }

--- a/ui/widget.js
+++ b/ui/widget.js
@@ -1,2 +1,166 @@
-// Step 5（feature/step05-widget-ui）で実装する
+'use strict';
+
 // フローティングウィジェット（待機/リスニング/処理中/確認/完了/エラーの6状態）
+// XSS防止のため innerHTML は使用しない。テキストは textContent のみ使用。
+
+const STATES = {
+  IDLE: 'idle',
+  LISTENING: 'listening',
+  PROCESSING: 'processing',
+  CONFIRM: 'confirm',
+  SUCCESS: 'success',
+  ERROR: 'error',
+};
+
+const DEFAULT_SUCCESS_DURATION_MS = 3000;
+
+/**
+ * フローティングウィジェットを生成し document.body に追加する
+ * @returns {{ setState, getState, setTranscript, destroy }}
+ */
+function createWidget() {
+  // ── DOM 構築（innerHTML 禁止・DOM API のみ使用）──
+  const container = document.createElement('div');
+  container.id = 'vfa-widget';
+  container.setAttribute('data-state', STATES.IDLE);
+  container.setAttribute('role', 'status');
+  container.setAttribute('aria-live', 'polite');
+  container.style.display = 'none';
+
+  const statusEl = document.createElement('div');
+  statusEl.className = 'vfa-status';
+
+  const transcriptEl = document.createElement('div');
+  transcriptEl.className = 'vfa-transcript';
+
+  const messageEl = document.createElement('div');
+  messageEl.className = 'vfa-message';
+
+  const confirmEl = document.createElement('div');
+  confirmEl.className = 'vfa-confirm';
+  confirmEl.style.display = 'none';
+
+  const yesBtn = document.createElement('button');
+  yesBtn.className = 'vfa-btn vfa-btn-yes';
+  yesBtn.textContent = 'はい';
+  yesBtn.setAttribute('type', 'button');
+
+  const noBtn = document.createElement('button');
+  noBtn.className = 'vfa-btn vfa-btn-no';
+  noBtn.textContent = 'いいえ';
+  noBtn.setAttribute('type', 'button');
+
+  confirmEl.appendChild(yesBtn);
+  confirmEl.appendChild(noBtn);
+
+  container.appendChild(statusEl);
+  container.appendChild(transcriptEl);
+  container.appendChild(messageEl);
+  container.appendChild(confirmEl);
+
+  document.body.appendChild(container);
+
+  // ── 内部状態 ──
+  let currentState = STATES.IDLE;
+  let confirmCallback = null;
+  let successTimer = null;
+
+  function clearSuccessTimer() {
+    if (successTimer !== null) {
+      clearTimeout(successTimer);
+      successTimer = null;
+    }
+  }
+
+  // ── ボタンイベント ──
+  yesBtn.addEventListener('click', () => {
+    if (confirmCallback) confirmCallback(true);
+  });
+
+  noBtn.addEventListener('click', () => {
+    if (confirmCallback) confirmCallback(false);
+  });
+
+  // ── 状態遷移 ──
+  function setState(state, options) {
+    clearSuccessTimer();
+    const opts = options || {};
+    currentState = state;
+    container.setAttribute('data-state', state);
+
+    // 確認ボタン・コールバックをリセット
+    confirmEl.style.display = 'none';
+    confirmCallback = null;
+
+    if (state === STATES.IDLE) {
+      container.style.display = 'none';
+      statusEl.textContent = '';
+      transcriptEl.textContent = '';
+      messageEl.textContent = '';
+      return;
+    }
+
+    container.style.display = 'block';
+
+    if (state === STATES.LISTENING) {
+      statusEl.textContent = 'リスニング中...';
+      transcriptEl.textContent = '';
+      messageEl.textContent = '';
+      return;
+    }
+
+    if (state === STATES.PROCESSING) {
+      statusEl.textContent = '処理中...';
+      if (opts.transcript !== undefined) {
+        transcriptEl.textContent = opts.transcript;
+      }
+      messageEl.textContent = '';
+      return;
+    }
+
+    if (state === STATES.CONFIRM) {
+      statusEl.textContent = '確認';
+      if (opts.transcript !== undefined) {
+        transcriptEl.textContent = opts.transcript;
+      }
+      messageEl.textContent = opts.message || '';
+      confirmEl.style.display = 'flex';
+      confirmCallback = opts.onConfirm || null;
+      return;
+    }
+
+    if (state === STATES.SUCCESS) {
+      statusEl.textContent = '完了';
+      messageEl.textContent = opts.message || '';
+      const duration =
+        opts.duration !== undefined ? opts.duration : DEFAULT_SUCCESS_DURATION_MS;
+      successTimer = setTimeout(() => setState(STATES.IDLE), duration);
+      return;
+    }
+
+    if (state === STATES.ERROR) {
+      statusEl.textContent = 'エラー';
+      messageEl.textContent = opts.message || '';
+      return;
+    }
+  }
+
+  return {
+    setState,
+    getState() {
+      return currentState;
+    },
+    setTranscript(text) {
+      transcriptEl.textContent = text;
+    },
+    destroy() {
+      container.remove();
+    },
+  };
+}
+
+// Node.js (Jest) 環境向け CommonJS エクスポート
+// ブラウザ環境（Content Script）では importScripts() または <script> タグで読み込む
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { createWidget, STATES };
+}


### PR DESCRIPTION
## 概要

Issue #4 (Step 5) の実装。

## 変更内容

- `ui/widget.js`: フローティングウィジェット（6状態管理）を実装
- `content.css`: ウィジェットのスタイルを実装
- `__tests__/unit/widget.test.js`: 48テストを追加

## 実装詳細

### `ui/widget.js`

- `createWidget()` ファクトリ関数でDOM生成・状態管理
- 6状態: `idle` / `listening` / `processing` / `confirm` / `success` / `error`
- **XSS防止**: `innerHTML` 不使用 → `textContent` / DOM API のみ
- `success` 状態は3秒後に `idle` へ自動遷移（カスタム duration 対応）
- `confirm` 状態では はい/いいえ ボタンと `onConfirm` コールバック
- `data-state` 属性で CSS 状態スタイルと連動
- アクセシビリティ: `role="status"`, `aria-live="polite"`

### `content.css`

- 状態ごとに左ボーダー色で視覚的フィードバック
  - listening: 青 / processing: グレー / confirm: 黄 / success: 緑 / error: 赤

## テスト結果

```
Tests: 132 passed, 132 total

Coverage:
  widget.js: Stmts 100% | Branch 84.21% | Funcs 100% | Lines 100%
  Overall:   Stmts 99.33% | Branch 86.15% | Funcs 100% | Lines 99.28%
```

カバレッジ閾値（branches:70% / functions・lines・statements:80%）すべて達成。

## 完了条件チェック

- [x] テスト先行（Red → Green → Refactor）
- [x] カバレッジ branches:70% / functions・lines・statements:80% 以上
- [x] ESLint エラーなし
- [x] CI 通過（予定）
- [x] develop へ PR 作成

Closes #4