### PR TITLE
feat(rule-engine): Step 6 QUICK_PATTERNSルールエンジン実装（TDD）(#5)

### DIFF
--- a/__tests__/unit/ruleEngine.test.js
+++ b/__tests__/unit/ruleEngine.test.js
@@ -1,0 +1,299 @@
+'use strict';
+
+const ruleEngine = require('../../lib/ruleEngine');
+
+describe('RuleEngine', () => {
+  // ─── navigate patterns ────────────────────────────────────────────────────
+
+  describe('navigate patterns - オブジェクト名のみ', () => {
+    test.each([
+      ['商談',           'Opportunity'],
+      ['取引先',         'Account'],
+      ['リード',         'Lead'],
+      ['取引先責任者',   'Contact'],
+      ['タスク',         'Task'],
+      ['行動',           'Event'],
+      ['ToDo',           'Task'],
+    ])('「%s」→ navigate/%s/list', (input, object) => {
+      const result = ruleEngine.match(input);
+      expect(result).toEqual(expect.objectContaining({
+        action: 'navigate',
+        object,
+        target: 'list',
+        confidence: 1.0,
+      }));
+    });
+  });
+
+  describe('navigate patterns - 一覧/リスト付き', () => {
+    test.each([
+      ['商談の一覧',     'Opportunity'],
+      ['商談一覧',       'Opportunity'],
+      ['商談リスト',     'Opportunity'],
+      ['商談のリスト',   'Opportunity'],
+      ['取引先の一覧',   'Account'],
+    ])('「%s」→ navigate/%s/list', (input, object) => {
+      const result = ruleEngine.match(input);
+      expect(result).toEqual(expect.objectContaining({
+        action: 'navigate',
+        object,
+        target: 'list',
+        confidence: 1.0,
+      }));
+    });
+  });
+
+  describe('navigate patterns - 動詞付き（をなし）', () => {
+    test.each([
+      ['商談出して',   'Opportunity'],
+      ['商談開いて',   'Opportunity'],
+      ['商談見せて',   'Opportunity'],
+      ['商談表示',     'Opportunity'],
+    ])('「%s」→ navigate/%s/list', (input, object) => {
+      const result = ruleEngine.match(input);
+      expect(result).toEqual(expect.objectContaining({
+        action: 'navigate',
+        object,
+        target: 'list',
+      }));
+    });
+  });
+
+  describe('navigate patterns - 動詞付き（をあり）', () => {
+    test.each([
+      ['商談を開いて'],
+      ['商談を出して'],
+      ['商談を見せて'],
+      ['商談を表示'],
+    ])('「%s」→ navigate/Opportunity/list', (input) => {
+      const result = ruleEngine.match(input);
+      expect(result).toEqual(expect.objectContaining({
+        action: 'navigate',
+        object: 'Opportunity',
+        target: 'list',
+      }));
+    });
+  });
+
+  describe('navigate patterns - 一覧＋動詞（DESIGN_DOC主要テストケース）', () => {
+    test('「商談一覧出して」→ navigate/Opportunity/list (full object)', () => {
+      const result = ruleEngine.match('商談一覧出して');
+      expect(result).toEqual({
+        action: 'navigate',
+        object: 'Opportunity',
+        target: 'list',
+        confidence: 1.0,
+        message: '商談の一覧を開きます',
+      });
+    });
+
+    test.each([
+      ['商談の一覧出して',   'Opportunity'],
+      ['商談一覧を開いて',   'Opportunity'],
+      ['商談の一覧を開いて', 'Opportunity'],
+      ['取引先一覧出して',   'Account'],
+    ])('「%s」→ navigate/%s/list', (input, object) => {
+      const result = ruleEngine.match(input);
+      expect(result).toEqual(expect.objectContaining({
+        action: 'navigate',
+        object,
+        target: 'list',
+      }));
+    });
+  });
+
+  describe('navigate - message フィールド', () => {
+    test('商談 → message に日本語ラベルが含まれる', () => {
+      expect(ruleEngine.match('商談').message).toBe('商談の一覧を開きます');
+    });
+
+    test('取引先 → message', () => {
+      expect(ruleEngine.match('取引先').message).toBe('取引先の一覧を開きます');
+    });
+
+    test('リード → message', () => {
+      expect(ruleEngine.match('リード').message).toBe('リードの一覧を開きます');
+    });
+  });
+
+  describe('navigate - マッチしないパターン（→ null）', () => {
+    test('「田中商事の商談を開いて」→ null', () => {
+      expect(ruleEngine.match('田中商事の商談を開いて')).toBeNull();
+    });
+
+    test('「田中商事の商談の金額を500万にして」→ null', () => {
+      expect(ruleEngine.match('田中商事の商談の金額を500万にして')).toBeNull();
+    });
+  });
+
+  // ─── confirm patterns ─────────────────────────────────────────────────────
+
+  describe('confirm patterns - はい系', () => {
+    test.each([
+      ['はい'],
+      ['うん'],
+      ['OK'],
+      ['オッケー'],
+      ['いいよ'],
+      ['お願い'],
+      ['実行して'],
+      ['そう'],
+      ['ええ'],
+    ])('「%s」→ confirm/true', (input) => {
+      expect(ruleEngine.match(input)).toEqual({ action: 'confirm', value: true });
+    });
+  });
+
+  describe('confirm patterns - いいえ系', () => {
+    test.each([
+      ['いいえ'],
+      ['いや'],
+      ['やめて'],
+      ['キャンセル'],
+      ['違う'],
+      ['やめ'],
+      ['だめ'],
+      ['ダメ'],
+    ])('「%s」→ confirm/false', (input) => {
+      expect(ruleEngine.match(input)).toEqual({ action: 'confirm', value: false });
+    });
+  });
+
+  // ─── back patterns ────────────────────────────────────────────────────────
+
+  describe('back patterns', () => {
+    test.each([
+      ['戻って'],
+      ['戻る'],
+      ['バック'],
+      ['前の画面'],
+    ])('「%s」→ back', (input) => {
+      expect(ruleEngine.match(input)).toEqual({ action: 'back' });
+    });
+  });
+
+  // ─── stop patterns ────────────────────────────────────────────────────────
+
+  describe('stop patterns', () => {
+    test.each([
+      ['止めて'],
+      ['停止'],
+      ['ストップ'],
+      ['終わり'],
+      ['おしまい'],
+    ])('「%s」→ stop', (input) => {
+      expect(ruleEngine.match(input)).toEqual({ action: 'stop' });
+    });
+  });
+
+  // ─── undo patterns ────────────────────────────────────────────────────────
+
+  describe('undo patterns', () => {
+    test.each([
+      ['元に戻して'],
+      ['アンドゥ'],
+      ['取り消し'],
+      ['取り消して'],
+      ['やり直し'],
+    ])('「%s」→ undo', (input) => {
+      expect(ruleEngine.match(input)).toEqual({ action: 'undo' });
+    });
+  });
+
+  // ─── select patterns ──────────────────────────────────────────────────────
+
+  describe('select patterns - 半角数字', () => {
+    test.each([
+      ['1', 1],
+      ['2', 2],
+      ['3', 3],
+      ['4', 4],
+      ['5', 5],
+    ])('「%s」→ select/%d', (input, expected) => {
+      expect(ruleEngine.match(input)).toEqual({ action: 'select', index: expected });
+    });
+  });
+
+  describe('select patterns - 番付き', () => {
+    test.each([
+      ['1番', 1],
+      ['2番', 2],
+      ['3番', 3],
+      ['4番', 4],
+      ['5番', 5],
+    ])('「%s」→ select/%d', (input, expected) => {
+      expect(ruleEngine.match(input)).toEqual({ action: 'select', index: expected });
+    });
+  });
+
+  describe('select patterns - 漢数字', () => {
+    test.each([
+      ['一', 1],
+      ['二', 2],
+      ['三', 3],
+      ['四', 4],
+      ['五', 5],
+    ])('「%s」→ select/%d', (input, expected) => {
+      expect(ruleEngine.match(input)).toEqual({ action: 'select', index: expected });
+    });
+  });
+
+  describe('select patterns - 範囲外はマッチしない', () => {
+    test.each([
+      ['6'],
+      ['0'],
+      ['六'],
+    ])('「%s」→ null（範囲外）', (input) => {
+      expect(ruleEngine.match(input)).toBeNull();
+    });
+  });
+
+  // ─── help patterns ────────────────────────────────────────────────────────
+
+  describe('help patterns', () => {
+    test.each([
+      ['ヘルプ'],
+      ['使い方'],
+      ['何ができる'],
+      ['help'],
+    ])('「%s」→ help', (input) => {
+      expect(ruleEngine.match(input)).toEqual({ action: 'help' });
+    });
+  });
+
+  // ─── edge cases ───────────────────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    test('空文字 → null', () => {
+      expect(ruleEngine.match('')).toBeNull();
+    });
+
+    test('null → null', () => {
+      expect(ruleEngine.match(null)).toBeNull();
+    });
+
+    test('undefined → null', () => {
+      expect(ruleEngine.match(undefined)).toBeNull();
+    });
+
+    test('スペースのみ → null', () => {
+      expect(ruleEngine.match('   ')).toBeNull();
+    });
+
+    test('記号のみ → null', () => {
+      expect(ruleEngine.match('!!!!')).toBeNull();
+    });
+
+    test('前後のスペースはトリムして処理', () => {
+      expect(ruleEngine.match(' はい ')).toEqual({ action: 'confirm', value: true });
+    });
+
+    test('長文 → null', () => {
+      expect(ruleEngine.match('田中商事というお客さんの電話番号を変更してください')).toBeNull();
+    });
+
+    test('数値型 → null', () => {
+      expect(ruleEngine.match(123)).toBeNull();
+    });
+  });
+});

--- a/lib/ruleEngine.js
+++ b/lib/ruleEngine.js
@@ -1,2 +1,111 @@
-// Step 6（feature/step06-rule-engine）で実装する
-// QUICK_PATTERNS による正規表現マッチング（LLMバイパス）
+'use strict';
+
+// lib/ruleEngine.js
+// QUICK_PATTERNS による正規表現マッチング（LLMバイパス 30〜40% 目標）
+
+// 日本語ラベル → Salesforce API 名
+const LABEL_TO_API = {
+  '商談':         'Opportunity',
+  '取引先':       'Account',
+  '取引先責任者': 'Contact',
+  'リード':       'Lead',
+  'タスク':       'Task',
+  '行動':         'Event',
+  'ToDo':         'Task',
+};
+
+// 漢数字 → 整数変換
+function toNumber(str) {
+  const kanjiMap = { '一': 1, '二': 2, '三': 3, '四': 4, '五': 5 };
+  if (kanjiMap[str] !== undefined) return kanjiMap[str];
+  return parseInt(str, 10);
+}
+
+const OBJECT_NAMES = '商談|取引先責任者|取引先|リード|タスク|行動|ToDo';
+
+const QUICK_PATTERNS = [
+  // ── オブジェクト一覧への遷移 ────────────────────────────────────────
+  {
+    patterns: [
+      // 例: 「商談」「商談の一覧」「商談リスト」
+      new RegExp(`^(${OBJECT_NAMES})(の)?(一覧|リスト)?$`),
+      // 例: 「商談を開いて」「商談出して」「商談を表示」
+      new RegExp(`^(${OBJECT_NAMES})(を)?(開いて|出して|見せて|表示)$`),
+      // 例: 「商談一覧出して」「商談の一覧を開いて」
+      new RegExp(`^(${OBJECT_NAMES})(の)?(一覧|リスト)(を)?(出して|開いて|見せて|表示)?$`),
+    ],
+    resolve: (m) => ({
+      action: 'navigate',
+      object: LABEL_TO_API[m[1]],
+      target: 'list',
+      confidence: 1.0,
+      message: `${m[1]}の一覧を開きます`,
+    }),
+  },
+
+  // ── 確認応答（はい） ─────────────────────────────────────────────────
+  {
+    patterns: [/^(はい|うん|OK|オッケー|いいよ|お願い|実行して|そう|ええ)$/i],
+    resolve: () => ({ action: 'confirm', value: true }),
+  },
+
+  // ── 確認応答（いいえ） ───────────────────────────────────────────────
+  {
+    patterns: [/^(いいえ|いや|やめて|キャンセル|違う|やめ|だめ|ダメ)$/],
+    resolve: () => ({ action: 'confirm', value: false }),
+  },
+
+  // ── 戻る ─────────────────────────────────────────────────────────────
+  {
+    patterns: [/^(戻って|戻る|バック|前の画面)$/],
+    resolve: () => ({ action: 'back' }),
+  },
+
+  // ── 停止 ─────────────────────────────────────────────────────────────
+  {
+    patterns: [/^(止めて|停止|ストップ|終わり|おしまい)$/],
+    resolve: () => ({ action: 'stop' }),
+  },
+
+  // ── 元に戻す（undo） ─────────────────────────────────────────────────
+  {
+    patterns: [/^(元に戻して|アンドゥ|取り消し|取り消して|やり直し)$/],
+    resolve: () => ({ action: 'undo' }),
+  },
+
+  // ── 番号選択（1〜5、一〜五） ─────────────────────────────────────────
+  {
+    patterns: [/^([1-5一二三四五])(番)?$/],
+    resolve: (m) => ({ action: 'select', index: toNumber(m[1]) }),
+  },
+
+  // ── ヘルプ ───────────────────────────────────────────────────────────
+  {
+    patterns: [/^(ヘルプ|使い方|何ができる|help)$/i],
+    resolve: () => ({ action: 'help' }),
+  },
+];
+
+/**
+ * 発話テキストをルールにマッチさせる。
+ * @param {string} text - 音声認識で得られたテキスト
+ * @returns {object|null} マッチしたアクションオブジェクト、または null（LLMへ委譲）
+ */
+function match(text) {
+  if (!text || typeof text !== 'string') return null;
+  const trimmed = text.trim();
+  if (!trimmed) return null;
+
+  for (const rule of QUICK_PATTERNS) {
+    for (const pattern of rule.patterns) {
+      const m = trimmed.match(pattern);
+      if (m) return rule.resolve(m);
+    }
+  }
+
+  return null;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { match, QUICK_PATTERNS, LABEL_TO_API };
+}


### PR DESCRIPTION
## 概要

Issue #5 の実装。`lib/ruleEngine.js` を TDD（Red → Green → Refactor）で実装。

## 実装内容

### `lib/ruleEngine.js`
- `LABEL_TO_API`: 日本語オブジェクト名 → Salesforce API名マッピング
- `QUICK_PATTERNS`: 8種類のルール定義
  - **navigate**: オブジェクト一覧への遷移（3パターン対応）
    - パターン1: 「商談」「商談の一覧」「商談リスト」
    - パターン2: 「商談を開いて」「商談出して」「商談を表示」
    - パターン3: 「商談一覧出して」「商談の一覧を開いて」
  - **confirm**: 「はい」系（true）/ 「いいえ」系（false）
  - **back**: 「戻って」「戻る」「バック」「前の画面」
  - **stop**: 「止めて」「停止」「ストップ」「終わり」「おしまい」
  - **undo**: 「元に戻して」「アンドゥ」「取り消し」「取り消して」「やり直し」
  - **select**: 半角1-5 / 漢数字一-五 / 番付き（`toNumber` ヘルパー）
  - **help**: 「ヘルプ」「使い方」「何ができる」「help」
- `match(text)`: マッチしない場合は `null` を返してLLMに委譲

### `__tests__/unit/ruleEngine.test.js`
- 91テストケース（全パターン網羅＋エッジケース）

## カバレッジ

| メトリクス | 結果 | 閾値 |
|-----------|------|------|
| Statements | **100%** | 80% |
| Branch | **92.85%** | 70% |
| Functions | **100%** | 80% |
| Lines | **100%** | 80% |

## 確認事項

- [x] テスト先行（Red → Green → Refactor）
- [x] 全91テストケースパス
- [x] カバレッジ閾値クリア
- [x] ESLint エラーなし
- [x] 既存223テストへの回帰なし