### PR TITLE
feat(salesforce-api): Step 7 Salesforce REST APIクライアント実装（TDD）(#6)

### DIFF
--- a/__tests__/mocks/salesforceApi.js
+++ b/__tests__/mocks/salesforceApi.js
@@ -1,0 +1,24 @@
+'use strict';
+
+// lib/salesforceApi.js の Jest モック
+// recordResolver 等のテストで利用する
+
+const salesforceApi = {
+  sosl:         jest.fn(),
+  soql:         jest.fn(),
+  getRecord:    jest.fn(),
+  createRecord: jest.fn(),
+  updateRecord: jest.fn(),
+  deleteRecord: jest.fn(),
+  SF_ERROR_CODES: {
+    TOKEN_EXPIRED:     'TOKEN_EXPIRED',
+    PERMISSION_DENIED: 'PERMISSION_DENIED',
+    RATE_LIMITED:      'RATE_LIMITED',
+    CONFLICT:          'CONFLICT',
+    NOT_FOUND:         'NOT_FOUND',
+    SERVER_ERROR:      'SERVER_ERROR',
+    UNKNOWN_ERROR:     'UNKNOWN_ERROR',
+  },
+};
+
+module.exports = salesforceApi;

--- a/__tests__/unit/salesforceApi.test.js
+++ b/__tests__/unit/salesforceApi.test.js
@@ -1,0 +1,261 @@
+'use strict';
+
+const salesforceApi = require('../../lib/salesforceApi');
+const mockResponses = require('../mocks/salesforceResponses');
+
+const INSTANCE_URL = 'https://example.salesforce.com';
+const ACCESS_TOKEN = 'test_access_token_xxx';
+const API_VERSION = 'v59.0';
+
+global.fetch = jest.fn();
+
+function mockFetchOk(body, status = 200) {
+  global.fetch.mockResolvedValueOnce({ ok: true, status, json: async () => body });
+}
+
+function mockFetch204() {
+  global.fetch.mockResolvedValueOnce({ ok: true, status: 204, json: async () => null });
+}
+
+function mockFetchError(status, body = []) {
+  global.fetch.mockResolvedValueOnce({ ok: false, status, json: async () => body });
+}
+
+beforeEach(() => { global.fetch.mockClear(); });
+
+describe('SalesforceApi', () => {
+
+  describe('sosl - SOSL全文検索', () => {
+    test('正常: 検索結果レコードを返す', async () => {
+      mockFetchOk({ searchRecords: mockResponses.soslSingleResult.searchRecords });
+
+      const results = await salesforceApi.sosl(INSTANCE_URL, ACCESS_TOKEN, '田中商事', 'Opportunity', ['Id', 'Name', 'Amount']);
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      const [url, options] = global.fetch.mock.calls[0];
+      expect(url).toContain(`/services/data/${API_VERSION}/search/`);
+      expect(decodeURIComponent(url)).toContain('Opportunity(Id, Name, Amount)');
+      expect(decodeURIComponent(url)).toContain('FIND {田中商事}');
+      expect(options.method).toBe('GET');
+      expect(options.headers['Authorization']).toBe(`Bearer ${ACCESS_TOKEN}`);
+      expect(results).toHaveLength(1);
+      expect(results[0].Name).toBe('田中商事_2025年度契約');
+    });
+
+    test('正常: 0件の場合は空配列を返す', async () => {
+      mockFetchOk({ searchRecords: [] });
+      const results = await salesforceApi.sosl(INSTANCE_URL, ACCESS_TOKEN, '存在しない', 'Opportunity');
+      expect(results).toEqual([]);
+    });
+
+    test('正常: fields省略時は [Id, Name] をデフォルト使用', async () => {
+      mockFetchOk({ searchRecords: [] });
+      await salesforceApi.sosl(INSTANCE_URL, ACCESS_TOKEN, 'test', 'Account');
+      const [url] = global.fetch.mock.calls[0];
+      expect(decodeURIComponent(url)).toContain('Account(Id, Name)');
+    });
+
+    test('SOSL特殊文字をエスケープする', async () => {
+      mockFetchOk({ searchRecords: [] });
+      await salesforceApi.sosl(INSTANCE_URL, ACCESS_TOKEN, '田中&商事', 'Account');
+      const [url] = global.fetch.mock.calls[0];
+      expect(decodeURIComponent(url)).toContain('田中\\&商事');
+    });
+
+    test('searchRecordsキーがない場合は空配列を返す', async () => {
+      mockFetchOk({});
+      const results = await salesforceApi.sosl(INSTANCE_URL, ACCESS_TOKEN, 'test', 'Account');
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe('soql - SOQLクエリ実行', () => {
+    test('正常: クエリ結果レコードを返す', async () => {
+      const records = [{ Id: '001xxx', Name: '田中商事' }];
+      mockFetchOk({ records, done: true, totalSize: 1 });
+
+      const query = "SELECT Id, Name FROM Account WHERE Name LIKE '%田中%' LIMIT 10";
+      const results = await salesforceApi.soql(INSTANCE_URL, ACCESS_TOKEN, query);
+
+      const [url, options] = global.fetch.mock.calls[0];
+      expect(url).toContain(`/services/data/${API_VERSION}/query/`);
+      expect(decodeURIComponent(url)).toContain(query);
+      expect(options.method).toBe('GET');
+      expect(results).toEqual(records);
+    });
+
+    test('正常: 0件の場合は空配列を返す', async () => {
+      mockFetchOk({ records: [], done: true, totalSize: 0 });
+      const results = await salesforceApi.soql(INSTANCE_URL, ACCESS_TOKEN, 'SELECT Id FROM Account LIMIT 1');
+      expect(results).toEqual([]);
+    });
+
+    test('recordsキーがない場合は空配列を返す', async () => {
+      mockFetchOk({});
+      const results = await salesforceApi.soql(INSTANCE_URL, ACCESS_TOKEN, 'SELECT Id FROM Account');
+      expect(results).toEqual([]);
+    });
+  });
+
+  describe('getRecord - レコード取得', () => {
+    test('正常: レコードを返す', async () => {
+      mockFetchOk(mockResponses.opportunityRecord);
+      const record = await salesforceApi.getRecord(INSTANCE_URL, ACCESS_TOKEN, 'Opportunity', '006xx0000001AAAA');
+
+      const [url, options] = global.fetch.mock.calls[0];
+      expect(url).toContain('/sobjects/Opportunity/006xx0000001AAAA');
+      expect(options.method).toBe('GET');
+      expect(record.Name).toBe('田中商事_2025年度契約');
+      expect(record.Amount).toBe(5000000);
+    });
+
+    test('正常: fields指定時はURLクエリパラメータに含まれる', async () => {
+      mockFetchOk(mockResponses.opportunityRecord);
+      await salesforceApi.getRecord(INSTANCE_URL, ACCESS_TOKEN, 'Opportunity', '006xx0000001AAAA', ['Id', 'Name', 'Amount']);
+      const [url] = global.fetch.mock.calls[0];
+      expect(url).toContain('fields=Id,Name,Amount');
+    });
+
+    test('正常: fields未指定時はクエリパラメータなし', async () => {
+      mockFetchOk(mockResponses.opportunityRecord);
+      await salesforceApi.getRecord(INSTANCE_URL, ACCESS_TOKEN, 'Opportunity', '006xx0000001AAAA');
+      const [url] = global.fetch.mock.calls[0];
+      expect(url).not.toContain('fields=');
+    });
+  });
+
+  describe('createRecord - レコード作成', () => {
+    test('正常: 作成レスポンスを返す', async () => {
+      const createResponse = { id: '001newxxx', success: true, errors: [] };
+      mockFetchOk(createResponse, 201);
+
+      const result = await salesforceApi.createRecord(INSTANCE_URL, ACCESS_TOKEN, 'Account', { Name: 'テスト取引先', Phone: '03-0000-0000' });
+
+      const [url, options] = global.fetch.mock.calls[0];
+      expect(url).toContain(`/services/data/${API_VERSION}/sobjects/Account`);
+      expect(options.method).toBe('POST');
+      const body = JSON.parse(options.body);
+      expect(body.Name).toBe('テスト取引先');
+      expect(result.success).toBe(true);
+      expect(result.id).toBe('001newxxx');
+    });
+  });
+
+  describe('updateRecord - レコード更新', () => {
+    test('正常: 204を受け取り { success: true } を返す', async () => {
+      mockFetch204();
+      const result = await salesforceApi.updateRecord(INSTANCE_URL, ACCESS_TOKEN, 'Opportunity', '006xx0000001AAAA', { Amount: 8000000 });
+
+      const [url, options] = global.fetch.mock.calls[0];
+      expect(url).toContain('/sobjects/Opportunity/006xx0000001AAAA');
+      expect(options.method).toBe('PATCH');
+      expect(JSON.parse(options.body).Amount).toBe(8000000);
+      expect(result).toEqual({ success: true });
+    });
+
+    test('競合検知あり: LastModifiedDate が一致する場合は更新する', async () => {
+      mockFetchOk({ LastModifiedDate: '2025-01-01T00:00:00.000Z' });
+      mockFetch204();
+
+      const result = await salesforceApi.updateRecord(INSTANCE_URL, ACCESS_TOKEN, 'Opportunity', '006xx0000001AAAA', { Amount: 8000000 }, '2025-01-01T00:00:00.000Z');
+
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+      expect(result).toEqual({ success: true });
+    });
+
+    test('競合検知あり: LastModifiedDate が不一致の場合は CONFLICT エラー', async () => {
+      mockFetchOk({ LastModifiedDate: '2025-06-01T12:00:00.000Z' });
+
+      await expect(
+        salesforceApi.updateRecord(INSTANCE_URL, ACCESS_TOKEN, 'Opportunity', '006xx0000001AAAA', { Amount: 8000000 }, '2025-01-01T00:00:00.000Z')
+      ).rejects.toMatchObject({ code: 'CONFLICT', currentLastModifiedDate: '2025-06-01T12:00:00.000Z' });
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    test('競合検知なし: expectedLastModifiedDate が null の場合は getRecord をスキップ', async () => {
+      mockFetch204();
+      await salesforceApi.updateRecord(INSTANCE_URL, ACCESS_TOKEN, 'Opportunity', '006xx0000001AAAA', { Amount: 8000000 }, null);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('deleteRecord - レコード削除', () => {
+    test('正常: 204を受け取り { success: true } を返す', async () => {
+      mockFetch204();
+      const result = await salesforceApi.deleteRecord(INSTANCE_URL, ACCESS_TOKEN, 'Account', '001xxx');
+
+      const [url, options] = global.fetch.mock.calls[0];
+      expect(url).toContain('/sobjects/Account/001xxx');
+      expect(options.method).toBe('DELETE');
+      expect(result).toEqual({ success: true });
+    });
+  });
+
+  describe('エラーハンドリング', () => {
+    test('401 → TOKEN_EXPIRED エラー', async () => {
+      mockFetchError(401);
+      await expect(salesforceApi.soql(INSTANCE_URL, ACCESS_TOKEN, 'SELECT Id FROM Account LIMIT 1')).rejects.toMatchObject({ code: 'TOKEN_EXPIRED' });
+    });
+
+    test('403 → PERMISSION_DENIED エラー（sfErrorCodeも設定）', async () => {
+      mockFetchError(403, mockResponses.insufficientPermissions);
+      await expect(salesforceApi.getRecord(INSTANCE_URL, ACCESS_TOKEN, 'Opportunity', '006xxx')).rejects.toMatchObject({ code: 'PERMISSION_DENIED', sfErrorCode: 'INSUFFICIENT_ACCESS_ON_CROSS_REFERENCE_ENTITY' });
+    });
+
+    test('404 → NOT_FOUND エラー', async () => {
+      mockFetchError(404);
+      await expect(salesforceApi.getRecord(INSTANCE_URL, ACCESS_TOKEN, 'Opportunity', '006notexist')).rejects.toMatchObject({ code: 'NOT_FOUND' });
+    });
+
+    test('429 → RATE_LIMITED エラー', async () => {
+      mockFetchError(429);
+      await expect(salesforceApi.soql(INSTANCE_URL, ACCESS_TOKEN, 'SELECT Id FROM Account LIMIT 1')).rejects.toMatchObject({ code: 'RATE_LIMITED' });
+    });
+
+    test('500 → SERVER_ERROR エラー', async () => {
+      mockFetchError(500);
+      await expect(salesforceApi.soql(INSTANCE_URL, ACCESS_TOKEN, 'SELECT Id FROM Account LIMIT 1')).rejects.toMatchObject({ code: 'SERVER_ERROR' });
+    });
+
+    test('503 → SERVER_ERROR エラー', async () => {
+      mockFetchError(503);
+      await expect(salesforceApi.soql(INSTANCE_URL, ACCESS_TOKEN, 'SELECT Id FROM Account LIMIT 1')).rejects.toMatchObject({ code: 'SERVER_ERROR' });
+    });
+
+    test('400 バリデーションエラー → sfErrorCode が設定される', async () => {
+      mockFetchError(400, [{ errorCode: 'FIELD_CUSTOM_VALIDATION_EXCEPTION', message: '必須項目が未入力です' }]);
+      await expect(salesforceApi.createRecord(INSTANCE_URL, ACCESS_TOKEN, 'Account', { Phone: '03-0000-0000' })).rejects.toMatchObject({ sfErrorCode: 'FIELD_CUSTOM_VALIDATION_EXCEPTION' });
+    });
+  });
+
+  describe('リクエストヘッダー', () => {
+    test('Authorization ヘッダーが Bearer トークンで設定される', async () => {
+      mockFetchOk({ records: [] });
+      await salesforceApi.soql(INSTANCE_URL, 'my_token_xyz', 'SELECT Id FROM Account');
+      expect(global.fetch.mock.calls[0][1].headers['Authorization']).toBe('Bearer my_token_xyz');
+    });
+
+    test('Content-Type が application/json に設定される', async () => {
+      mockFetchOk({ records: [] });
+      await salesforceApi.soql(INSTANCE_URL, ACCESS_TOKEN, 'SELECT Id FROM Account');
+      expect(global.fetch.mock.calls[0][1].headers['Content-Type']).toBe('application/json');
+    });
+
+    test('Accept が application/json に設定される', async () => {
+      mockFetchOk({ records: [] });
+      await salesforceApi.soql(INSTANCE_URL, ACCESS_TOKEN, 'SELECT Id FROM Account');
+      expect(global.fetch.mock.calls[0][1].headers['Accept']).toBe('application/json');
+    });
+  });
+
+  describe('SF_ERROR_CODES エクスポート', () => {
+    test('主要エラーコードが定義されている', () => {
+      expect(salesforceApi.SF_ERROR_CODES.TOKEN_EXPIRED).toBe('TOKEN_EXPIRED');
+      expect(salesforceApi.SF_ERROR_CODES.PERMISSION_DENIED).toBe('PERMISSION_DENIED');
+      expect(salesforceApi.SF_ERROR_CODES.RATE_LIMITED).toBe('RATE_LIMITED');
+      expect(salesforceApi.SF_ERROR_CODES.CONFLICT).toBe('CONFLICT');
+      expect(salesforceApi.SF_ERROR_CODES.NOT_FOUND).toBe('NOT_FOUND');
+      expect(salesforceApi.SF_ERROR_CODES.SERVER_ERROR).toBe('SERVER_ERROR');
+    });
+  });
+});

--- a/lib/salesforceApi.js
+++ b/lib/salesforceApi.js
@@ -1,2 +1,133 @@
-// Step 7（feature/step07-salesforce-api）で実装する
-// SOQL/SOSL 検索・CRUD・エラーハンドリング
+'use strict';
+
+const API_VERSION = 'v59.0';
+
+const SF_ERROR_CODES = {
+  TOKEN_EXPIRED:     'TOKEN_EXPIRED',
+  PERMISSION_DENIED: 'PERMISSION_DENIED',
+  RATE_LIMITED:      'RATE_LIMITED',
+  CONFLICT:          'CONFLICT',
+  NOT_FOUND:         'NOT_FOUND',
+  SERVER_ERROR:      'SERVER_ERROR',
+  UNKNOWN_ERROR:     'UNKNOWN_ERROR',
+};
+
+function createHeaders(accessToken) {
+  return {
+    'Authorization': `Bearer ${accessToken}`,
+    'Content-Type': 'application/json',
+    'Accept': 'application/json',
+  };
+}
+
+async function handleResponse(response) {
+  if (response.ok) {
+    if (response.status === 204) return null;
+    return response.json();
+  }
+
+  const error = new Error();
+
+  if (response.status === 401) {
+    error.code = SF_ERROR_CODES.TOKEN_EXPIRED;
+    error.message = 'アクセストークンの有効期限が切れています';
+  } else if (response.status === 404) {
+    error.code = SF_ERROR_CODES.NOT_FOUND;
+    error.message = 'レコードが見つかりません';
+  } else if (response.status === 429) {
+    error.code = SF_ERROR_CODES.RATE_LIMITED;
+    error.message = 'リクエスト数の上限に達しました。しばらく待ってから再試行してください';
+  } else if (response.status >= 500) {
+    error.code = SF_ERROR_CODES.SERVER_ERROR;
+    error.message = 'Salesforceサーバーエラーが発生しました';
+  } else {
+    let body = [];
+    try { body = await response.json(); } catch (_) { /* ignore */ }
+    error.code = (response.status === 403)
+      ? SF_ERROR_CODES.PERMISSION_DENIED
+      : (body[0]?.errorCode || SF_ERROR_CODES.UNKNOWN_ERROR);
+    error.message = body[0]?.message || '不明なエラーが発生しました';
+    error.sfErrorCode = body[0]?.errorCode;
+  }
+
+  throw error;
+}
+
+function escapeSOSL(term) {
+  return term.replace(/[?&|!{}[\]()^~*:\\\'"+-]/g, '\\$&');
+}
+
+async function sosl(instanceUrl, accessToken, searchTerm, objectName, fields = ['Id', 'Name']) {
+  const fieldStr = fields.join(', ');
+  const query = `FIND {${escapeSOSL(searchTerm)}} IN ALL FIELDS RETURNING ${objectName}(${fieldStr}) LIMIT 10`;
+  const url = `${instanceUrl}/services/data/${API_VERSION}/search/?q=${encodeURIComponent(query)}`;
+
+  const response = await fetch(url, { method: 'GET', headers: createHeaders(accessToken) });
+  const data = await handleResponse(response);
+  return data?.searchRecords ?? [];
+}
+
+async function soql(instanceUrl, accessToken, query) {
+  const url = `${instanceUrl}/services/data/${API_VERSION}/query/?q=${encodeURIComponent(query)}`;
+
+  const response = await fetch(url, { method: 'GET', headers: createHeaders(accessToken) });
+  const data = await handleResponse(response);
+  return data?.records ?? [];
+}
+
+async function getRecord(instanceUrl, accessToken, objectName, recordId, fields = []) {
+  let url = `${instanceUrl}/services/data/${API_VERSION}/sobjects/${objectName}/${recordId}`;
+  if (fields.length > 0) {
+    url += `?fields=${fields.join(',')}`;
+  }
+
+  const response = await fetch(url, { method: 'GET', headers: createHeaders(accessToken) });
+  return handleResponse(response);
+}
+
+async function createRecord(instanceUrl, accessToken, objectName, fields) {
+  const url = `${instanceUrl}/services/data/${API_VERSION}/sobjects/${objectName}`;
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: createHeaders(accessToken),
+    body: JSON.stringify(fields),
+  });
+  return handleResponse(response);
+}
+
+async function updateRecord(instanceUrl, accessToken, objectName, recordId, fields, expectedLastModifiedDate = null) {
+  if (expectedLastModifiedDate !== null) {
+    const current = await getRecord(instanceUrl, accessToken, objectName, recordId, ['LastModifiedDate']);
+    if (current.LastModifiedDate !== expectedLastModifiedDate) {
+      const error = new Error('レコードが別のユーザーによって更新されています');
+      error.code = SF_ERROR_CODES.CONFLICT;
+      error.currentLastModifiedDate = current.LastModifiedDate;
+      throw error;
+    }
+  }
+
+  const url = `${instanceUrl}/services/data/${API_VERSION}/sobjects/${objectName}/${recordId}`;
+
+  const response = await fetch(url, {
+    method: 'PATCH',
+    headers: createHeaders(accessToken),
+    body: JSON.stringify(fields),
+  });
+
+  if (response.status === 204) return { success: true };
+  return handleResponse(response);
+}
+
+async function deleteRecord(instanceUrl, accessToken, objectName, recordId) {
+  const url = `${instanceUrl}/services/data/${API_VERSION}/sobjects/${objectName}/${recordId}`;
+
+  const response = await fetch(url, { method: 'DELETE', headers: createHeaders(accessToken) });
+
+  if (response.status === 204) return { success: true };
+  return handleResponse(response);
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { sosl, soql, getRecord, createRecord, updateRecord, deleteRecord, SF_ERROR_CODES, API_VERSION };
+}


### PR DESCRIPTION
## 概要

Issue #6 の実装。`lib/salesforceApi.js` を TDD（Red → Green → Refactor）で実装。

## 実装内容

### `lib/salesforceApi.js`

| 関数 | 説明 |
|------|------|
| `sosl()` | SOSL全文検索（特殊文字エスケープ、デフォルトfields対応） |
| `soql()` | SOQLクエリ実行 |
| `getRecord()` | 単一レコード取得（fields指定対応） |
| `createRecord()` | レコード作成（POST） |
| `updateRecord()` | レコード更新（PATCH）+ `LastModifiedDate` 競合検知 |
| `deleteRecord()` | レコード削除（DELETE） |
| `handleResponse()` | HTTPエラーを統一コードでスロー |

**エラーコード統一管理（`SF_ERROR_CODES`）:**
- 401 → `TOKEN_EXPIRED`
- 403 → `PERMISSION_DENIED`
- 404 → `NOT_FOUND`
- 429 → `RATE_LIMITED`
- 5xx → `SERVER_ERROR`
- PATCH/DELETE競合 → `CONFLICT`

### `__tests__/unit/salesforceApi.test.js`（28テストケース）
- SOQL/SOSLリクエスト組み立て・ヘッダー検証
- CRUD操作の正常系
- 競合検知（LastModifiedDate 一致/不一致）
- エラーハンドリング（401/403/404/429/500/503/400）

### `__tests__/mocks/salesforceApi.js`
- 将来ステップ（Step 10 recordResolver等）用Jestモック

## カバレッジ

| メトリクス | 結果 | 閾値 |
|-----------|------|------|
| Statements | **95%** | 80% |
| Branch | **84%** | 70% |
| Functions | **100%** | 80% |
| Lines | **96%** | 80% |

## 確認事項

- [x] テスト先行（Red → Green → Refactor）
- [x] 全28テストケースパス（全体251件回帰なし）
- [x] カバレッジ閾値クリア
- [x] ESLint エラーなし