### PR TITLE
feat(worker): Step 8 Cloudflare Workers実装（TDD） (#21相当)

### DIFF
--- a/__tests__/unit/worker.test.js
+++ b/__tests__/unit/worker.test.js
@@ -1,0 +1,285 @@
+/** @jest-environment node */
+'use strict';
+
+const { handleRequest, DAILY_LIMIT, RATE_LIMIT_PER_MINUTE } = require('../../worker/index');
+
+// ── KV モック ──────────────────────────────────────────────
+
+function createMockKV() {
+  const store = new Map();
+  return {
+    get:  jest.fn(async (key) => store.get(key) ?? null),
+    put:  jest.fn(async (key, value, _options) => { store.set(key, value); }),
+    _store: store,
+  };
+}
+
+// ── fetch モック ───────────────────────────────────────────
+
+global.fetch = jest.fn();
+
+function mockClaudeOk(json) {
+  global.fetch.mockResolvedValueOnce({
+    ok:   true,
+    json: async () => ({ content: [{ text: JSON.stringify(json) }] }),
+  });
+}
+
+function mockClaudeError(status = 500) {
+  global.fetch.mockResolvedValueOnce({ ok: false, status, json: async () => ({}) });
+}
+
+// ── 定数 ───────────────────────────────────────────────
+
+const TEST_USER      = 'user_test_123';
+const VALID_METADATA = 'Opportunity（商談）: Name（商談名）, Amount（金額）';
+
+const NAV_RESPONSE = {
+  action:     'navigate',
+  object:     'Opportunity',
+  target:     'list',
+  confidence: 0.95,
+  message:    '商談の一覧を開きます',
+};
+
+// ── ヘルパー ───────────────────────────────────────────
+
+function makePostRequest(body) {
+  return new Request('https://worker.example.com/api/v1/analyze', {
+    method:  'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body:    JSON.stringify(body),
+  });
+}
+
+function makeGetUsageRequest(userId) {
+  const headers = userId ? { 'X-User-Id': userId } : {};
+  return new Request('https://worker.example.com/api/v1/usage', {
+    method: 'GET',
+    headers,
+  });
+}
+
+// ── セットアップ ────────────────────────────────────────────
+
+beforeEach(() => { global.fetch.mockClear(); });
+
+describe('Worker', () => {
+  let kv;
+  let env;
+
+  beforeEach(() => {
+    kv  = createMockKV();
+    env = { USAGE_KV: kv, CLAUDE_API_KEY: 'test_api_key' };
+  });
+
+  // ── POST /api/v1/analyze ──────────────────────────────────────────
+
+  describe('POST /api/v1/analyze', () => {
+    test('正常: Claude の JSON レスポンスを 200 で返す', async () => {
+      mockClaudeOk(NAV_RESPONSE);
+
+      const res = await handleRequest(
+        makePostRequest({ text: '商談一覧を開いて', metadata: VALID_METADATA, user_id: TEST_USER }),
+        env,
+      );
+
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.action).toBe('navigate');
+      expect(body.object).toBe('Opportunity');
+    });
+
+    test('正常: Claude API に text と API キーが送信される', async () => {
+      mockClaudeOk(NAV_RESPONSE);
+
+      await handleRequest(
+        makePostRequest({ text: '商談を開いて', metadata: VALID_METADATA, user_id: TEST_USER }),
+        env,
+      );
+
+      const [, options] = global.fetch.mock.calls[0];
+      const sent = JSON.parse(options.body);
+      expect(sent.messages[0].content).toBe('商談を開いて');
+      expect(options.headers['x-api-key']).toBe('test_api_key');
+    });
+
+    test('正常: システムプロンプトに metadata が挿入される', async () => {
+      mockClaudeOk(NAV_RESPONSE);
+
+      await handleRequest(
+        makePostRequest({ text: '商談を開いて', metadata: VALID_METADATA, user_id: TEST_USER }),
+        env,
+      );
+
+      const [, options] = global.fetch.mock.calls[0];
+      const sent = JSON.parse(options.body);
+      expect(sent.system).toContain(VALID_METADATA);
+    });
+
+    test('400: text が空文字', async () => {
+      const res = await handleRequest(
+        makePostRequest({ text: '', metadata: VALID_METADATA, user_id: TEST_USER }),
+        env,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    test('400: text が欠けている', async () => {
+      const res = await handleRequest(
+        makePostRequest({ metadata: VALID_METADATA, user_id: TEST_USER }),
+        env,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    test('400: text が文字列でない（数値型）', async () => {
+      const res = await handleRequest(
+        makePostRequest({ text: 123, metadata: VALID_METADATA, user_id: TEST_USER }),
+        env,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    test('400: user_id が欠けている', async () => {
+      const res = await handleRequest(
+        makePostRequest({ text: '商談を開いて', metadata: VALID_METADATA }),
+        env,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    test('400: JSON でないリクエストボディ', async () => {
+      const req = new Request('https://worker.example.com/api/v1/analyze', {
+        method:  'POST',
+        headers: { 'Content-Type': 'text/plain' },
+        body:    'not json',
+      });
+      const res = await handleRequest(req, env);
+      expect(res.status).toBe(400);
+    });
+
+    test('429: 1分あたりのレートリミットを超えた場合', async () => {
+      const minute = Math.floor(Date.now() / 60000);
+      kv._store.set(`rate:${TEST_USER}:${minute}`, String(RATE_LIMIT_PER_MINUTE));
+
+      const res = await handleRequest(
+        makePostRequest({ text: '商談を開いて', metadata: VALID_METADATA, user_id: TEST_USER }),
+        env,
+      );
+
+      expect(res.status).toBe(429);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    test('利用回数を KV usage キーにインクリメントする', async () => {
+      mockClaudeOk(NAV_RESPONSE);
+
+      await handleRequest(
+        makePostRequest({ text: '商談を開いて', metadata: VALID_METADATA, user_id: TEST_USER }),
+        env,
+      );
+
+      const usageCalls = kv.put.mock.calls.filter(([key]) => key.startsWith('usage:'));
+      expect(usageCalls.length).toBeGreaterThan(0);
+    });
+
+    test('502: Claude API がエラーを返した場合', async () => {
+      mockClaudeError(500);
+
+      const res = await handleRequest(
+        makePostRequest({ text: '商談を開いて', metadata: VALID_METADATA, user_id: TEST_USER }),
+        env,
+      );
+
+      expect(res.status).toBe(502);
+    });
+
+    test('502: Claude が有効でない JSON を返した場合', async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok:   true,
+        json: async () => ({ content: [{ text: 'これはJSONではありません' }] }),
+      });
+
+      const res = await handleRequest(
+        makePostRequest({ text: '商談を開いて', metadata: VALID_METADATA, user_id: TEST_USER }),
+        env,
+      );
+
+      expect(res.status).toBe(502);
+    });
+
+    test('CORS ヘッダーが設定される', async () => {
+      mockClaudeOk(NAV_RESPONSE);
+
+      const res = await handleRequest(
+        makePostRequest({ text: '商談を開いて', metadata: VALID_METADATA, user_id: TEST_USER }),
+        env,
+      );
+
+      expect(res.headers.get('Access-Control-Allow-Origin')).toBeTruthy();
+    });
+  });
+
+  // ── GET /api/v1/usage ────────────────────────────────────────────
+
+  describe('GET /api/v1/usage', () => {
+    test('正常: 今日の利用回数を返す', async () => {
+      const today = new Date().toISOString().split('T')[0];
+      kv._store.set(`usage:${TEST_USER}:${today}`, '3');
+
+      const res  = await handleRequest(makeGetUsageRequest(TEST_USER), env);
+      expect(res.status).toBe(200);
+
+      const body = await res.json();
+      expect(body.today_count).toBe(3);
+      expect(body.daily_limit).toBe(DAILY_LIMIT);
+      expect(body.plan).toBe('free');
+    });
+
+    test('正常: 初回利用（KVにデータなし）は today_count が 0', async () => {
+      const res  = await handleRequest(makeGetUsageRequest(TEST_USER), env);
+      const body = await res.json();
+      expect(body.today_count).toBe(0);
+    });
+
+    test('400: X-User-Id ヘッダーがない場合', async () => {
+      const res = await handleRequest(makeGetUsageRequest(null), env);
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // ── OPTIONS (CORS preflight) ──────────────────────────────────────────
+
+  describe('OPTIONS (CORS preflight)', () => {
+    test('OPTIONS リクエストに 204 を返す', async () => {
+      const req = new Request('https://worker.example.com/api/v1/analyze', { method: 'OPTIONS' });
+      const res = await handleRequest(req, env);
+      expect(res.status).toBe(204);
+    });
+  });
+
+  // ── ルーティング ─────────────────────────────────────────────
+
+  describe('存在しないルート', () => {
+    test('未定義パスは 404 を返す', async () => {
+      const req = new Request('https://worker.example.com/api/v1/unknown', { method: 'GET' });
+      const res = await handleRequest(req, env);
+      expect(res.status).toBe(404);
+    });
+  });
+
+  // ── エクスポート定数 ───────────────────────────────────────────
+
+  describe('エクスポート定数', () => {
+    test('DAILY_LIMIT は正の整数', () => {
+      expect(typeof DAILY_LIMIT).toBe('number');
+      expect(DAILY_LIMIT).toBeGreaterThan(0);
+    });
+
+    test('RATE_LIMIT_PER_MINUTE は正の整数', () => {
+      expect(typeof RATE_LIMIT_PER_MINUTE).toBe('number');
+      expect(RATE_LIMIT_PER_MINUTE).toBeGreaterThan(0);
+    });
+  });
+});

--- a/worker/index.js
+++ b/worker/index.js
@@ -1,3 +1,226 @@
-// Step 8（feature/step08-cloudflare-worker）で実装する
-// POST /api/v1/analyze  : LLM 意図解析エンドポイント
-// GET  /api/v1/usage    : 利用回数確認エンドポイント
+'use strict';
+
+/* global USAGE_KV, CLAUDE_API_KEY, addEventListener */
+
+// ── 定数 ────────────────────────────────────────────────────────
+
+const DAILY_LIMIT          = 10;
+const RATE_LIMIT_PER_MINUTE = 10;
+const CLAUDE_API_URL        = 'https://api.anthropic.com/v1/messages';
+const CLAUDE_MODEL          = 'claude-haiku-4-5-20251001';
+
+// ── システムプロンプト（固定部分） ──────────────────────────────────────────
+
+const SYSTEM_PROMPT = `あなたはSalesforceの音声操作アシスタントです。
+ユーザーの音声入力（テキストに変換済み）を受け取り、
+Salesforceに対する操作指示をJSON形式で出力してください。
+
+必ず以下のルールに従ってください：
+- 出力はJSON形式のみ。説明文やMarkdownは一切含めない
+- 日本語の発話を正確に解釈する
+- 曖昧な場合は推測せず、confidenceを下げて確認を促すmessageを返す
+- 1回の発話に対して 1 つのアクションのみ返す
+
+## 対応するアクション
+
+1. navigate - レコードまたはオブジェクトの一覧画面に遷移する
+2. search   - 条件に合うレコードを検索する
+3. create   - 新規レコードを作成する
+4. update   - 既存レコードの項目を更新する
+5. summary  - 情報を要約・集計して回答する
+6. unknown  - Salesforce操作と判断できない場合
+
+## 出力JSONスキーマ
+
+■ navigate
+{"action":"navigate","object":"APIオブジェクト名","search_term":"レコード特定キーワードまたはnull","target":"record|list","confidence":0.0-1.0,"message":"日本語フィードバック"}
+
+■ search
+{"action":"search","object":"APIオブジェクト名","conditions":{},"keyword":"キーワードまたはnull","confidence":0.0-1.0,"message":"日本語フィードバック"}
+
+■ create
+{"action":"create","object":"APIオブジェクト名","fields":{},"missing_fields":[],"confidence":0.0-1.0,"message":"日本語フィードバック"}
+
+■ update
+{"action":"update","object":"APIオブジェクト名","search_term":"対象レコード特定キーワード","fields":{},"confidence":0.0-1.0,"message":"日本語フィードバック"}
+
+■ summary
+{"action":"summary","summary_type":"today_schedule|pipeline|recent_activities|count|custom","object":"APIオブジェクト名またはnull","conditions":{},"confidence":0.0-1.0,"message":"日本語フィードバック"}
+
+■ unknown
+{"action":"unknown","confidence":0.0,"message":"日本語フィードバック"}
+
+## 判定ルール
+
+【オブジェクト解決】
+- ユーザーは日本語ラベル（「商談」「取引先」等）で話す
+- 後述の「利用可能なオブジェクト一覧」を参照し、ラベルからAPI名に変換する
+
+【数値の正規化】
+- 「500万」→ 5000000 / 「1千万」→ 10000000
+
+【安全性ルール】
+- updateのmessageには必ず変更内容の確認を含める
+
+=== 利用可能なオブジェクト一覧 ===
+{{DYNAMIC_METADATA}}`;
+
+// ── CORS ──────────────────────────────────────────────────────────────
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin':  '*',
+  'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type, X-User-Id',
+  'Access-Control-Max-Age':       '86400',
+};
+
+// ── ユーティリティ ─────────────────────────────────────────────────────
+
+function jsonResponse(body, status) {
+  const code = (status !== undefined) ? status : 200;
+  return new Response(JSON.stringify(body), {
+    status:  code,
+    headers: Object.assign({ 'Content-Type': 'application/json' }, CORS_HEADERS),
+  });
+}
+
+function getRateKey(userId) {
+  const minute = Math.floor(Date.now() / 60000);
+  return `rate:${userId}:${minute}`;
+}
+
+function getUsageKey(userId) {
+  const today = new Date().toISOString().split('T')[0];
+  return `usage:${userId}:${today}`;
+}
+
+// ── KV 操作 ───────────────────────────────────────────────────────
+
+async function checkAndIncrementRate(userId, kv) {
+  const key     = getRateKey(userId);
+  const current = parseInt((await kv.get(key)) || '0', 10);
+  if (current >= RATE_LIMIT_PER_MINUTE) return false;
+  await kv.put(key, String(current + 1), { expirationTtl: 120 });
+  return true;
+}
+
+async function incrementUsage(userId, kv) {
+  const key     = getUsageKey(userId);
+  const current = parseInt((await kv.get(key)) || '0', 10);
+  await kv.put(key, String(current + 1), { expirationTtl: 172800 }); // 48h TTL
+}
+
+// ── Claude API 呼び出し ────────────────────────────────────────────
+
+async function callClaude(text, metadata, apiKey) {
+  const systemPrompt = SYSTEM_PROMPT.replace('{{DYNAMIC_METADATA}}', metadata || '');
+
+  const response = await fetch(CLAUDE_API_URL, {
+    method:  'POST',
+    headers: {
+      'Content-Type':      'application/json',
+      'x-api-key':         apiKey,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model:      CLAUDE_MODEL,
+      max_tokens: 500,
+      system:     systemPrompt,
+      messages:   [{ role: 'user', content: text }],
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Claude API error: ${response.status}`);
+  }
+
+  const data        = await response.json();
+  const textContent = data.content && data.content[0] && data.content[0].text;
+  if (!textContent) throw new Error('Empty response from Claude');
+
+  return JSON.parse(textContent);
+}
+
+// ── エンドポイントハンドラ ───────────────────────────────────────────────
+
+async function handleAnalyze(request, env) {
+  let body;
+  try {
+    body = await request.json();
+  } catch (_) {
+    return jsonResponse({ error: 'Invalid JSON body' }, 400);
+  }
+
+  const { text, metadata, user_id } = body;
+
+  if (!text || typeof text !== 'string' || !text.trim()) {
+    return jsonResponse({ error: 'text is required and must be a non-empty string' }, 400);
+  }
+  if (!user_id || typeof user_id !== 'string') {
+    return jsonResponse({ error: 'user_id is required' }, 400);
+  }
+
+  const allowed = await checkAndIncrementRate(user_id, env.USAGE_KV);
+  if (!allowed) {
+    return jsonResponse({ error: 'Rate limit exceeded. Please try again later.' }, 429);
+  }
+
+  let result;
+  try {
+    result = await callClaude(text, metadata, env.CLAUDE_API_KEY);
+  } catch (e) {
+    return jsonResponse({ error: 'LLM API error', details: e.message }, 502);
+  }
+
+  await incrementUsage(user_id, env.USAGE_KV);
+
+  return jsonResponse(result);
+}
+
+async function handleUsage(request, env) {
+  const userId = request.headers.get('X-User-Id');
+  if (!userId) {
+    return jsonResponse({ error: 'X-User-Id header is required' }, 400);
+  }
+
+  const countStr   = await env.USAGE_KV.get(getUsageKey(userId));
+  const todayCount = countStr ? parseInt(countStr, 10) : 0;
+
+  return jsonResponse({ today_count: todayCount, daily_limit: DAILY_LIMIT, plan: 'free' });
+}
+
+// ── メインルーター ──────────────────────────────────────────────────
+
+async function handleRequest(request, env) {
+  const url    = new URL(request.url);
+  const { method } = request;
+
+  if (method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: CORS_HEADERS });
+  }
+
+  if (method === 'POST' && url.pathname === '/api/v1/analyze') {
+    return handleAnalyze(request, env);
+  }
+
+  if (method === 'GET' && url.pathname === '/api/v1/usage') {
+    return handleUsage(request, env);
+  }
+
+  return new Response('Not Found', { status: 404 });
+}
+
+// ── モジュールエクスポート（Jest / Node.js） ────────────────────────────────
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { handleRequest, DAILY_LIMIT, RATE_LIMIT_PER_MINUTE };
+} else if (typeof addEventListener !== 'undefined') {
+  // Cloudflare Workers Service Worker format
+  addEventListener('fetch', (event) => {
+    const workerEnv = {
+      USAGE_KV:       typeof USAGE_KV !== 'undefined'       ? USAGE_KV       : null,
+      CLAUDE_API_KEY: typeof CLAUDE_API_KEY !== 'undefined' ? CLAUDE_API_KEY : null,
+    };
+    event.respondWith(handleRequest(event.request, workerEnv));
+  });
+}

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,15 @@
+name            = "voiceforce-worker"
+main            = "index.js"
+compatibility_date = "2024-01-01"
+
+# KV Namespace（利用回数カウント）
+# デプロイ前に以下のコマンドで KV を作成し、ID を設定してください:
+#   wrangler kv:namespace create "USAGE_KV"
+#   wrangler kv:namespace create "USAGE_KV" --preview
+[[kv_namespaces]]
+binding    = "USAGE_KV"
+id         = "YOUR_KV_NAMESPACE_ID_HERE"
+preview_id = "YOUR_KV_PREVIEW_NAMESPACE_ID_HERE"
+
+# Secrets（wrangler secret put で登録）:
+#   wrangler secret put CLAUDE_API_KEY


### PR DESCRIPTION
## Summary

- `worker/index.js`: Cloudflare Workers バックエンド実装
  - `POST /api/v1/analyze`: Claude Haiku API呼び出し・意図解析JSON返却
  - `GET /api/v1/usage`: KV Storage から今日の利用回数を返す
  - レートリミット: 10 req/min per user（KV: `rate:userId:minute`）
  - 利用回数カウント: KV `usage:userId:YYYY-MM-DD`（48h TTL）
  - バリデーション: text必須・user_id必須・型チェック
  - CORS ヘッダー設定（`Access-Control-Allow-Origin: *`）
  - Service Worker形式（CommonJS互換 + Cloudflare両対応）
- `__tests__/unit/worker.test.js`: 20テストケース
  - `@jest-environment node`（Node.js 18+ ネイティブ Fetch API 使用）
  - KV / fetch モックによる完全ユニットテスト
- `worker/wrangler.toml`: Cloudflare Workers 設定（KV binding, secret）
- `.github/workflows/deploy-worker.yml`: main push 時に自動デプロイ

## Test plan

- [x] `npx jest __tests__/unit/worker.test.js` → 20/20 PASS
- [x] `npm test` → 271/271 PASS（全スイート影響なし）
- [x] カバレッジ目標維持（Statements 98.73% / Branch 86.33% / Functions 100% / Lines 98.9%）

🤖 Generated with [Claude Code](https://claude.com/claude-code)