### PR TITLE
feat(record-resolver): Step 10 recordResolver・candidateList実装（TDD）

### DIFF
--- a/__tests__/unit/candidateList.test.js
+++ b/__tests__/unit/candidateList.test.js
@@ -1,0 +1,191 @@
+'use strict';
+
+const { createCandidateList } = require('../../ui/candidateList');
+
+// ---------------------------------------------------------------------------
+// テスト用フィクスチャ
+// ---------------------------------------------------------------------------
+const CANDIDATES = [
+  { Id: 'id1', Name: '田中商事' },
+  { Id: 'id2', Name: 'ABC株式会社' },
+  { Id: 'id3', Name: 'テスト商会' },
+];
+
+// ===========================================================================
+// createCandidateList
+// ===========================================================================
+describe('createCandidateList', () => {
+  let list;
+
+  beforeEach(() => {
+    list = createCandidateList();
+  });
+
+  afterEach(() => {
+    list.destroy();
+  });
+
+  // ── DOM 初期状態 ────────────────────────────────────────────────────────
+  describe('初期状態', () => {
+    test('document.body に #vfa-candidate-list が追加される', () => {
+      expect(document.getElementById('vfa-candidate-list')).not.toBeNull();
+    });
+
+    test('初期状態は非表示', () => {
+      const el = document.getElementById('vfa-candidate-list');
+      expect(el.style.display).toBe('none');
+    });
+
+    test('role="list" 属性が設定されている', () => {
+      const el = document.getElementById('vfa-candidate-list');
+      expect(el.getAttribute('role')).toBe('list');
+    });
+  });
+
+  // ── show ────────────────────────────────────────────────────────────────
+  describe('show()', () => {
+    test('候補を渡すと表示される', () => {
+      list.show(CANDIDATES, jest.fn());
+      const el = document.getElementById('vfa-candidate-list');
+      expect(el.style.display).toBe('block');
+    });
+
+    test('候補の数だけアイテムが生成される', () => {
+      list.show(CANDIDATES, jest.fn());
+      const items = document.querySelectorAll('.vfa-candidate-item');
+      expect(items.length).toBe(CANDIDATES.length);
+    });
+
+    test('各アイテムに番号が表示される', () => {
+      list.show(CANDIDATES, jest.fn());
+      const nums = document.querySelectorAll('.vfa-candidate-num');
+      expect(nums[0].textContent).toBe('1');
+      expect(nums[1].textContent).toBe('2');
+      expect(nums[2].textContent).toBe('3');
+    });
+
+    test('各アイテムに Name が表示される（XSS防止: textContent）', () => {
+      list.show(CANDIDATES, jest.fn());
+      const names = document.querySelectorAll('.vfa-candidate-name');
+      expect(names[0].textContent).toBe('田中商事');
+      expect(names[1].textContent).toBe('ABC株式会社');
+    });
+
+    test('Name がなく Subject があるレコードは Subject を表示する', () => {
+      list.show([{ Id: 'id1', Subject: '電話フォローアップ' }], jest.fn());
+      const name = document.querySelector('.vfa-candidate-name');
+      expect(name.textContent).toBe('電話フォローアップ');
+    });
+
+    test('Name も Subject もない場合は Id を表示する', () => {
+      list.show([{ Id: 'unknown-id' }], jest.fn());
+      const name = document.querySelector('.vfa-candidate-name');
+      expect(name.textContent).toBe('unknown-id');
+    });
+
+    test('data-index 属性が 1-based で設定される', () => {
+      list.show(CANDIDATES, jest.fn());
+      const items = document.querySelectorAll('.vfa-candidate-item');
+      expect(items[0].getAttribute('data-index')).toBe('1');
+      expect(items[2].getAttribute('data-index')).toBe('3');
+    });
+
+    test('空配列を渡すと非表示のまま', () => {
+      list.show([], jest.fn());
+      const el = document.getElementById('vfa-candidate-list');
+      expect(el.style.display).toBe('none');
+    });
+
+    test('再 show で前の候補が上書きされる', () => {
+      list.show(CANDIDATES, jest.fn());
+      list.show([{ Id: 'new', Name: '新候補' }], jest.fn());
+      const items = document.querySelectorAll('.vfa-candidate-item');
+      expect(items.length).toBe(1);
+      expect(document.querySelector('.vfa-candidate-name').textContent).toBe('新候補');
+    });
+
+    test('onSelect が null でも例外が出ない', () => {
+      expect(() => list.show(CANDIDATES, null)).not.toThrow();
+    });
+  });
+
+  // ── クリックイベント ─────────────────────────────────────────────────────
+  describe('クリックイベント', () => {
+    test('アイテムをクリックすると onSelect が呼ばれる', () => {
+      const onSelect = jest.fn();
+      list.show(CANDIDATES, onSelect);
+      const items = document.querySelectorAll('.vfa-candidate-item');
+      items[1].click();
+      expect(onSelect).toHaveBeenCalledWith(2, CANDIDATES[1]);
+    });
+
+    test('1番目クリックで index=1, record=CANDIDATES[0] が渡される', () => {
+      const onSelect = jest.fn();
+      list.show(CANDIDATES, onSelect);
+      document.querySelectorAll('.vfa-candidate-item')[0].click();
+      expect(onSelect).toHaveBeenCalledWith(1, CANDIDATES[0]);
+    });
+  });
+
+  // ── hide ────────────────────────────────────────────────────────────────
+  describe('hide()', () => {
+    test('hide() で非表示になる', () => {
+      list.show(CANDIDATES, jest.fn());
+      list.hide();
+      const el = document.getElementById('vfa-candidate-list');
+      expect(el.style.display).toBe('none');
+    });
+
+    test('hide() でアイテムがクリアされる', () => {
+      list.show(CANDIDATES, jest.fn());
+      list.hide();
+      const items = document.querySelectorAll('.vfa-candidate-item');
+      expect(items.length).toBe(0);
+    });
+  });
+
+  // ── selectByNumber ───────────────────────────────────────────────────────
+  describe('selectByNumber()', () => {
+    test('有効な番号で onSelect が呼ばれ true を返す', () => {
+      const onSelect = jest.fn();
+      list.show(CANDIDATES, onSelect);
+      const result = list.selectByNumber(2);
+      expect(result).toBe(true);
+      expect(onSelect).toHaveBeenCalledWith(2, CANDIDATES[1]);
+    });
+
+    test('1番を選択すると CANDIDATES[0] が渡される', () => {
+      const onSelect = jest.fn();
+      list.show(CANDIDATES, onSelect);
+      list.selectByNumber(1);
+      expect(onSelect).toHaveBeenCalledWith(1, CANDIDATES[0]);
+    });
+
+    test('範囲外の番号（0）は false を返す', () => {
+      list.show(CANDIDATES, jest.fn());
+      expect(list.selectByNumber(0)).toBe(false);
+    });
+
+    test('範囲外の番号（4 > length 3）は false を返す', () => {
+      list.show(CANDIDATES, jest.fn());
+      expect(list.selectByNumber(4)).toBe(false);
+    });
+
+    test('候補が表示されていない状態では false を返す', () => {
+      expect(list.selectByNumber(1)).toBe(false);
+    });
+
+    test('数値以外は false を返す', () => {
+      list.show(CANDIDATES, jest.fn());
+      expect(list.selectByNumber('1')).toBe(false);
+    });
+  });
+
+  // ── destroy ─────────────────────────────────────────────────────────────
+  describe('destroy()', () => {
+    test('destroy() で DOM から要素が削除される', () => {
+      list.destroy();
+      expect(document.getElementById('vfa-candidate-list')).toBeNull();
+    });
+  });
+});

--- a/__tests__/unit/recordResolver.test.js
+++ b/__tests__/unit/recordResolver.test.js
@@ -1,0 +1,197 @@
+'use strict';
+
+const { categorize, resolve, selectByIndex, RESULT_CATEGORY } = require('../../lib/recordResolver');
+
+// ---------------------------------------------------------------------------
+// テスト用フィクスチャ
+// ---------------------------------------------------------------------------
+function makeRecords(n) {
+  return Array.from({ length: n }, (_, i) => ({ Id: `id${i}`, Name: `レコード${i + 1}` }));
+}
+
+// ===========================================================================
+// RESULT_CATEGORY
+// ===========================================================================
+describe('RESULT_CATEGORY', () => {
+  test('4種のカテゴリが定義されている', () => {
+    expect(RESULT_CATEGORY.NOT_FOUND).toBe('not_found');
+    expect(RESULT_CATEGORY.SINGLE).toBe('single');
+    expect(RESULT_CATEGORY.MULTIPLE).toBe('multiple');
+    expect(RESULT_CATEGORY.TOO_MANY).toBe('too_many');
+  });
+});
+
+// ===========================================================================
+// categorize
+// ===========================================================================
+describe('categorize', () => {
+  test('0件 → NOT_FOUND', () => {
+    expect(categorize([])).toBe(RESULT_CATEGORY.NOT_FOUND);
+  });
+
+  test('1件 → SINGLE', () => {
+    expect(categorize(makeRecords(1))).toBe(RESULT_CATEGORY.SINGLE);
+  });
+
+  test('2件 → MULTIPLE', () => {
+    expect(categorize(makeRecords(2))).toBe(RESULT_CATEGORY.MULTIPLE);
+  });
+
+  test('5件 → MULTIPLE（上限）', () => {
+    expect(categorize(makeRecords(5))).toBe(RESULT_CATEGORY.MULTIPLE);
+  });
+
+  test('6件 → TOO_MANY（下限）', () => {
+    expect(categorize(makeRecords(6))).toBe(RESULT_CATEGORY.TOO_MANY);
+  });
+
+  test('10件 → TOO_MANY', () => {
+    expect(categorize(makeRecords(10))).toBe(RESULT_CATEGORY.TOO_MANY);
+  });
+
+  test('配列以外 → NOT_FOUND', () => {
+    expect(categorize(null)).toBe(RESULT_CATEGORY.NOT_FOUND);
+    expect(categorize(undefined)).toBe(RESULT_CATEGORY.NOT_FOUND);
+    expect(categorize('string')).toBe(RESULT_CATEGORY.NOT_FOUND);
+    expect(categorize(42)).toBe(RESULT_CATEGORY.NOT_FOUND);
+  });
+});
+
+// ===========================================================================
+// resolve
+// ===========================================================================
+describe('resolve', () => {
+  describe('NOT_FOUND（0件）', () => {
+    let result;
+    beforeEach(() => { result = resolve([]); });
+
+    test('category が not_found', () => {
+      expect(result.category).toBe(RESULT_CATEGORY.NOT_FOUND);
+    });
+    test('record が null', () => {
+      expect(result.record).toBeNull();
+    });
+    test('candidates が空配列', () => {
+      expect(result.candidates).toEqual([]);
+    });
+    test('message に再試行を促す文言がある', () => {
+      expect(result.message).toContain('見つかりません');
+    });
+  });
+
+  describe('SINGLE（1件）', () => {
+    const records = makeRecords(1);
+    let result;
+    beforeEach(() => { result = resolve(records); });
+
+    test('category が single', () => {
+      expect(result.category).toBe(RESULT_CATEGORY.SINGLE);
+    });
+    test('record が records[0]', () => {
+      expect(result.record).toBe(records[0]);
+    });
+    test('candidates が空配列', () => {
+      expect(result.candidates).toEqual([]);
+    });
+    test('message が null', () => {
+      expect(result.message).toBeNull();
+    });
+  });
+
+  describe('MULTIPLE（2〜5件）', () => {
+    const records = makeRecords(3);
+    let result;
+    beforeEach(() => { result = resolve(records); });
+
+    test('category が multiple', () => {
+      expect(result.category).toBe(RESULT_CATEGORY.MULTIPLE);
+    });
+    test('record が null', () => {
+      expect(result.record).toBeNull();
+    });
+    test('candidates が全レコード', () => {
+      expect(result.candidates).toBe(records);
+    });
+    test('message に件数と選択を促す文言がある', () => {
+      expect(result.message).toContain('3件');
+      expect(result.message).toContain('番号で選択');
+    });
+
+    test('5件のときも MULTIPLE', () => {
+      const r = resolve(makeRecords(5));
+      expect(r.category).toBe(RESULT_CATEGORY.MULTIPLE);
+      expect(r.message).toContain('5件');
+    });
+  });
+
+  describe('TOO_MANY（6+件）', () => {
+    const records = makeRecords(7);
+    let result;
+    beforeEach(() => { result = resolve(records); });
+
+    test('category が too_many', () => {
+      expect(result.category).toBe(RESULT_CATEGORY.TOO_MANY);
+    });
+    test('record が null', () => {
+      expect(result.record).toBeNull();
+    });
+    test('candidates が空配列', () => {
+      expect(result.candidates).toEqual([]);
+    });
+    test('message に件数と絞り込みを促す文言がある', () => {
+      expect(result.message).toContain('7件');
+      expect(result.message).toContain('絞り込');
+    });
+  });
+
+  describe('配列以外の入力', () => {
+    test('null は NOT_FOUND として扱う', () => {
+      expect(resolve(null).category).toBe(RESULT_CATEGORY.NOT_FOUND);
+    });
+  });
+});
+
+// ===========================================================================
+// selectByIndex
+// ===========================================================================
+describe('selectByIndex', () => {
+  const candidates = makeRecords(5);
+
+  test('index=1 は candidates[0] を返す', () => {
+    expect(selectByIndex(candidates, 1)).toBe(candidates[0]);
+  });
+
+  test('index=5 は candidates[4] を返す', () => {
+    expect(selectByIndex(candidates, 5)).toBe(candidates[4]);
+  });
+
+  test('index=3 は candidates[2] を返す', () => {
+    expect(selectByIndex(candidates, 3)).toBe(candidates[2]);
+  });
+
+  test('index=0 は null を返す（範囲外）', () => {
+    expect(selectByIndex(candidates, 0)).toBeNull();
+  });
+
+  test('index が candidates.length を超える場合は null', () => {
+    expect(selectByIndex(candidates, 6)).toBeNull();
+  });
+
+  test('index が負数の場合は null', () => {
+    expect(selectByIndex(candidates, -1)).toBeNull();
+  });
+
+  test('index が数値以外の場合は null', () => {
+    expect(selectByIndex(candidates, '1')).toBeNull();
+    expect(selectByIndex(candidates, null)).toBeNull();
+  });
+
+  test('candidates が配列以外の場合は null', () => {
+    expect(selectByIndex(null, 1)).toBeNull();
+    expect(selectByIndex(undefined, 1)).toBeNull();
+  });
+
+  test('空配列からの選択は null', () => {
+    expect(selectByIndex([], 1)).toBeNull();
+  });
+});

--- a/lib/recordResolver.js
+++ b/lib/recordResolver.js
@@ -1,2 +1,84 @@
-// Step 10（feature/step10-record-resolver）で実装する
-// 検索結果件数（0/1/2-5/6+件）による分岐ロジック
+'use strict';
+
+// lib/recordResolver.js
+// 検索結果件数（0 / 1 / 2-5 / 6+件）による分岐ロジック
+
+const RESULT_CATEGORY = {
+  NOT_FOUND: 'not_found', // 0件
+  SINGLE:    'single',    // 1件
+  MULTIPLE:  'multiple',  // 2〜5件
+  TOO_MANY:  'too_many',  // 6件以上
+};
+
+/**
+ * 検索結果配列を件数カテゴリに分類する
+ * @param {Array} records - Salesforce API が返したレコード配列
+ * @returns {string} RESULT_CATEGORY のいずれか
+ */
+function categorize(records) {
+  if (!Array.isArray(records)) return RESULT_CATEGORY.NOT_FOUND;
+  const count = records.length;
+  if (count === 0)  return RESULT_CATEGORY.NOT_FOUND;
+  if (count === 1)  return RESULT_CATEGORY.SINGLE;
+  if (count <= 5)   return RESULT_CATEGORY.MULTIPLE;
+  return RESULT_CATEGORY.TOO_MANY;
+}
+
+/**
+ * 検索結果を解決し、次に取るべきアクションを返す
+ * @param {Array} records - Salesforce API が返したレコード配列
+ * @returns {{ category: string, record: object|null, candidates: Array, message: string|null }}
+ */
+function resolve(records) {
+  const category = categorize(records);
+
+  switch (category) {
+    case RESULT_CATEGORY.NOT_FOUND:
+      return {
+        category,
+        record:     null,
+        candidates: [],
+        message:    '該当するレコードが見つかりませんでした。条件を変えて再度お試しください。',
+      };
+
+    case RESULT_CATEGORY.SINGLE:
+      return {
+        category,
+        record:     records[0],
+        candidates: [],
+        message:    null,
+      };
+
+    case RESULT_CATEGORY.MULTIPLE:
+      return {
+        category,
+        record:     null,
+        candidates: records,
+        message:    `${records.length}件見つかりました。番号で選択してください。`,
+      };
+
+    case RESULT_CATEGORY.TOO_MANY:
+      return {
+        category,
+        record:     null,
+        candidates: [],
+        message:    `${records.length}件以上見つかりました。条件を絞り込んでください。`,
+      };
+  }
+}
+
+/**
+ * 候補リストから 1-based インデックスでレコードを選択する
+ * @param {Array}  candidates - resolve() で得た candidates 配列
+ * @param {number} index      - 1-based の選択番号
+ * @returns {object|null} 選択されたレコード、または範囲外なら null
+ */
+function selectByIndex(candidates, index) {
+  if (!Array.isArray(candidates)) return null;
+  if (typeof index !== 'number' || index < 1 || index > candidates.length) return null;
+  return candidates[index - 1];
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { categorize, resolve, selectByIndex, RESULT_CATEGORY };
+}

--- a/ui/candidateList.js
+++ b/ui/candidateList.js
@@ -1,2 +1,101 @@
-// Step 10（feature/step10-record-resolver）で実装する
+'use strict';
+
+// ui/candidateList.js
 // 音声番号選択対応の候補リスト UI
+// XSS防止のため innerHTML は使用しない。textContent / DOM API のみ使用。
+
+/**
+ * 候補リスト UI を生成し document.body に追加する
+ * @returns {{ show, hide, selectByNumber, destroy }}
+ */
+function createCandidateList() {
+  const container = document.createElement('div');
+  container.id = 'vfa-candidate-list';
+  container.setAttribute('role', 'list');
+  container.style.display = 'none';
+
+  document.body.appendChild(container);
+
+  let selectCallback  = null;
+  let currentCandidates = [];
+
+  function clearItems() {
+    while (container.firstChild) {
+      container.removeChild(container.firstChild);
+    }
+  }
+
+  /**
+   * 候補リストを表示する
+   * @param {Array}    candidates - レコード配列（Name / Subject / Id を持つ）
+   * @param {Function} onSelect   - (index: number, record: object) => void
+   */
+  function show(candidates, onSelect) {
+    currentCandidates = Array.isArray(candidates) ? candidates : [];
+    selectCallback    = typeof onSelect === 'function' ? onSelect : null;
+
+    clearItems();
+
+    if (currentCandidates.length === 0) {
+      container.style.display = 'none';
+      return;
+    }
+
+    currentCandidates.forEach((record, i) => {
+      const item = document.createElement('div');
+      item.className = 'vfa-candidate-item';
+      item.setAttribute('role', 'listitem');
+      item.setAttribute('data-index', String(i + 1));
+
+      const numEl = document.createElement('span');
+      numEl.className = 'vfa-candidate-num';
+      numEl.textContent = String(i + 1);
+
+      const nameEl = document.createElement('span');
+      nameEl.className = 'vfa-candidate-name';
+      nameEl.textContent = record.Name || record.Subject || String(record.Id || '');
+
+      item.appendChild(numEl);
+      item.appendChild(nameEl);
+
+      item.addEventListener('click', () => {
+        if (selectCallback) selectCallback(i + 1, record);
+      });
+
+      container.appendChild(item);
+    });
+
+    container.style.display = 'block';
+  }
+
+  /** 候補リストを非表示にして状態をリセットする */
+  function hide() {
+    container.style.display = 'none';
+    selectCallback    = null;
+    currentCandidates = [];
+    clearItems();
+  }
+
+  /**
+   * 番号（1-based）でレコードを選択する（音声番号選択用）
+   * @param {number} n - 1-based の選択番号
+   * @returns {boolean} 選択できた場合 true
+   */
+  function selectByNumber(n) {
+    if (typeof n !== 'number' || n < 1 || n > currentCandidates.length) return false;
+    const record = currentCandidates[n - 1];
+    if (selectCallback) selectCallback(n, record);
+    return true;
+  }
+
+  /** DOM から候補リストを削除する */
+  function destroy() {
+    container.remove();
+  }
+
+  return { show, hide, selectByNumber, destroy };
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { createCandidateList };
+}


### PR DESCRIPTION
## 概要\n\nIssue #9 の対応。`lib/recordResolver.js` と `ui/candidateList.js` を TDD で実装。\n\n## 実装内容\n\n### `lib/recordResolver.js`\n- `RESULT_CATEGORY` 定数（`not_found` / `single` / `multiple` / `too_many`）\n- `categorize(records)` — 件数カテゴリ分類\n  - 0件 → `NOT_FOUND`\n  - 1件 → `SINGLE`\n  - 2〜5件 → `MULTIPLE`\n  - 6件以上 → `TOO_MANY`\n- `resolve(records)` — カテゴリに応じた `{ category, record, candidates, message }` を返す\n- `selectByIndex(candidates, index)` — 1-based インデックスでレコードを選択\n\n### `ui/candidateList.js`\n- `createCandidateList()` — 候補リスト UI を生成（DOM API のみ・innerHTML 禁止）\n  - `show(candidates, onSelect)` — 番号付きリストを表示\n  - `hide()` — 非表示・状態リセット\n  - `selectByNumber(n)` — 音声番号選択（1-based）\n  - `destroy()` — DOM から削除\n\n## テスト\n\n| ファイル | テスト件数 |\n|---------|----------|\n| `__tests__/unit/recordResolver.test.js` | 28件 |\n| `__tests__/unit/candidateList.test.js` | 20件 |\n\n## Closes\n\nCloses #9"