### PR TITLE
feat(undo): Step 11 undoStack・更新安全機能実装（TDD）

### DIFF
--- a/__tests__/integration/updateSafety.test.js
+++ b/__tests__/integration/updateSafety.test.js
@@ -1,0 +1,195 @@
+'use strict';
+
+const { createUndoStack }                   = require('../../lib/undoStack');
+const { updateRecord, getRecord, SF_ERROR_CODES } = require('../../lib/salesforceApi');
+
+// ---------------------------------------------------------------------------
+// 共通定数
+// ---------------------------------------------------------------------------
+const INSTANCE_URL = 'https://test.salesforce.com';
+const ACCESS_TOKEN = 'test-token';
+const OBJECT_NAME  = 'Opportunity';
+const RECORD_ID    = 'opp001';
+
+// ---------------------------------------------------------------------------
+// fetch モックヘルパー
+// ---------------------------------------------------------------------------
+function mockFetchOk(body) {
+  global.fetch.mockResolvedValueOnce({
+    ok:     true,
+    status: 200,
+    json:   async () => body,
+  });
+}
+
+function mockFetchNoContent() {
+  global.fetch.mockResolvedValueOnce({
+    ok:     true,
+    status: 204,
+    json:   async () => ({}),
+  });
+}
+
+function mockFetchError(status, body) {
+  global.fetch.mockResolvedValueOnce({
+    ok:     false,
+    status,
+    json:   async () => body || [{ errorCode: 'UNKNOWN', message: 'error' }],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// セットアップ / ティアダウン
+// ---------------------------------------------------------------------------
+beforeEach(() => {
+  global.fetch = jest.fn();
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+// ===========================================================================
+// 更新安全フロー統合テスト
+// ===========================================================================
+describe('更新安全フロー統合テスト', () => {
+
+  // ── 更新 → undo フロー ──────────────────────────────────────────────
+  describe('更新 → undo フロー', () => {
+    test('getRecord で前の値を取得し undoStack に push できる', async () => {
+      const undoStack = createUndoStack();
+      mockFetchOk({ Amount: 3000000, LastModifiedDate: '2026-01-01T00:00:00.000Z' });
+
+      const record = await getRecord(
+        INSTANCE_URL, ACCESS_TOKEN, OBJECT_NAME, RECORD_ID, ['Amount', 'LastModifiedDate']
+      );
+
+      undoStack.push({
+        objectName:     OBJECT_NAME,
+        recordId:       RECORD_ID,
+        previousFields: { Amount: record.Amount },
+        updatedFields:  { Amount: 5000000 },
+        timestamp:      Date.now(),
+      });
+
+      expect(undoStack.size()).toBe(1);
+      expect(undoStack.peek().previousFields.Amount).toBe(3000000);
+    });
+
+    test('undo: pop → updateRecord で以前の値に戻せる', async () => {
+      const undoStack = createUndoStack();
+      undoStack.push({
+        objectName:     OBJECT_NAME,
+        recordId:       RECORD_ID,
+        previousFields: { Amount: 3000000 },
+        updatedFields:  { Amount: 5000000 },
+        timestamp:      Date.now(),
+      });
+
+      mockFetchNoContent();
+      const entry  = undoStack.pop();
+      const result = await updateRecord(
+        INSTANCE_URL, ACCESS_TOKEN, entry.objectName, entry.recordId, entry.previousFields
+      );
+
+      expect(result).toEqual({ success: true });
+      expect(undoStack.isEmpty()).toBe(true);
+    });
+
+    test('複数回更新後、LIFO 順に undo できる', () => {
+      const undoStack = createUndoStack();
+      undoStack.push({
+        objectName: OBJECT_NAME, recordId: 'opp001',
+        previousFields: { Amount: 1000000 }, updatedFields: { Amount: 2000000 }, timestamp: 1,
+      });
+      undoStack.push({
+        objectName: OBJECT_NAME, recordId: 'opp002',
+        previousFields: { Amount: 3000000 }, updatedFields: { Amount: 4000000 }, timestamp: 2,
+      });
+
+      expect(undoStack.pop().recordId).toBe('opp002');
+      expect(undoStack.pop().recordId).toBe('opp001');
+      expect(undoStack.pop()).toBeNull();
+    });
+  });
+
+  // ── LastModifiedDate 競合検知 ───────────────────────────────────────────
+  describe('LastModifiedDate 競合検知', () => {
+    test('LastModifiedDate が一致すれば更新成功', async () => {
+      const lmd = '2026-01-01T00:00:00.000Z';
+      mockFetchOk({ LastModifiedDate: lmd });   // getRecord (競合チェック用)
+      mockFetchNoContent();                      // updateRecord 本体
+
+      const result = await updateRecord(
+        INSTANCE_URL, ACCESS_TOKEN, OBJECT_NAME, RECORD_ID,
+        { Amount: 5000000 }, lmd
+      );
+      expect(result).toEqual({ success: true });
+    });
+
+    test('LastModifiedDate が不一致なら CONFLICT エラーをスロー', async () => {
+      mockFetchOk({ LastModifiedDate: '2026-02-01T00:00:00.000Z' });
+
+      await expect(
+        updateRecord(
+          INSTANCE_URL, ACCESS_TOKEN, OBJECT_NAME, RECORD_ID,
+          { Amount: 5000000 }, '2026-01-01T00:00:00.000Z'
+        )
+      ).rejects.toMatchObject({ code: SF_ERROR_CODES.CONFLICT });
+    });
+
+    test('競合エラーに currentLastModifiedDate が含まれる', async () => {
+      mockFetchOk({ LastModifiedDate: '2026-02-01T00:00:00.000Z' });
+
+      let thrownError;
+      try {
+        await updateRecord(
+          INSTANCE_URL, ACCESS_TOKEN, OBJECT_NAME, RECORD_ID,
+          { Amount: 5000000 }, '2026-01-01T00:00:00.000Z'
+        );
+      } catch (e) {
+        thrownError = e;
+      }
+      expect(thrownError.currentLastModifiedDate).toBe('2026-02-01T00:00:00.000Z');
+    });
+
+    test('expectedLastModifiedDate なしなら競合チェックをスキップ', async () => {
+      mockFetchNoContent();
+      const result = await updateRecord(
+        INSTANCE_URL, ACCESS_TOKEN, OBJECT_NAME, RECORD_ID, { Amount: 5000000 }
+      );
+      expect(result).toEqual({ success: true });
+      expect(global.fetch).toHaveBeenCalledTimes(1); // getRecord なし
+    });
+  });
+
+  // ── undoStack 上限 ──────────────────────────────────────────────────
+  describe('undoStack 上限（10件）', () => {
+    test('11件更新しても undoStack は 10件だけ保持する', () => {
+      const undoStack = createUndoStack();
+      for (let i = 0; i < 11; i++) {
+        undoStack.push({
+          objectName: OBJECT_NAME, recordId: `opp${i}`,
+          previousFields: { Amount: i * 1000000 },
+          updatedFields:  { Amount: (i + 1) * 1000000 },
+          timestamp: i,
+        });
+      }
+      expect(undoStack.size()).toBe(10);
+    });
+
+    test('11回 undo すると 10回目以降は null が返る', () => {
+      const undoStack = createUndoStack();
+      for (let i = 0; i < 11; i++) {
+        undoStack.push({
+          objectName: OBJECT_NAME, recordId: `opp${i}`,
+          previousFields: { Amount: i * 1000000 },
+          updatedFields:  { Amount: (i + 1) * 1000000 },
+          timestamp: i,
+        });
+      }
+      for (let i = 0; i < 10; i++) undoStack.pop();
+      expect(undoStack.pop()).toBeNull();
+    });
+  });
+});

--- a/__tests__/unit/undoStack.test.js
+++ b/__tests__/unit/undoStack.test.js
@@ -1,0 +1,176 @@
+'use strict';
+
+const { createUndoStack, MAX_STACK_SIZE } = require('../../lib/undoStack');
+
+// ---------------------------------------------------------------------------
+// テスト用フィクスチャ
+// ---------------------------------------------------------------------------
+function makeEntry(i = 0) {
+  return {
+    objectName:     'Opportunity',
+    recordId:       `id${i}`,
+    previousFields: { Amount: 1000000 * (i + 1) },
+    updatedFields:  { Amount: 2000000 * (i + 1) },
+    timestamp:      i,
+  };
+}
+
+// ===========================================================================
+// MAX_STACK_SIZE
+// ===========================================================================
+describe('MAX_STACK_SIZE', () => {
+  test('最大スタックサイズが 10 である', () => {
+    expect(MAX_STACK_SIZE).toBe(10);
+  });
+});
+
+// ===========================================================================
+// createUndoStack
+// ===========================================================================
+describe('createUndoStack', () => {
+  let stack;
+
+  beforeEach(() => {
+    stack = createUndoStack();
+  });
+
+  // ── isEmpty / size ───────────────────────────────────────────────────
+  describe('isEmpty() / size()', () => {
+    test('初期状態は isEmpty=true, size=0', () => {
+      expect(stack.isEmpty()).toBe(true);
+      expect(stack.size()).toBe(0);
+    });
+
+    test('push 後は isEmpty=false', () => {
+      stack.push(makeEntry());
+      expect(stack.isEmpty()).toBe(false);
+    });
+
+    test('size は push した件数を返す', () => {
+      stack.push(makeEntry(1));
+      stack.push(makeEntry(2));
+      expect(stack.size()).toBe(2);
+    });
+  });
+
+  // ── push ─────────────────────────────────────────────────────────────────
+  describe('push()', () => {
+    test('エントリを追加できる', () => {
+      stack.push(makeEntry(1));
+      expect(stack.size()).toBe(1);
+    });
+
+    test('null を push しても size は変わらない', () => {
+      stack.push(null);
+      expect(stack.size()).toBe(0);
+    });
+
+    test('undefined を push しても size は変わらない', () => {
+      stack.push(undefined);
+      expect(stack.size()).toBe(0);
+    });
+
+    test('文字列を push しても size は変わらない', () => {
+      stack.push('string');
+      expect(stack.size()).toBe(0);
+    });
+
+    test(`MAX_STACK_SIZE(${MAX_STACK_SIZE})件までは全て保持する`, () => {
+      for (let i = 0; i < MAX_STACK_SIZE; i++) stack.push(makeEntry(i));
+      expect(stack.size()).toBe(MAX_STACK_SIZE);
+    });
+
+    test(`${MAX_STACK_SIZE + 1}件目に最古のエントリが削除される`, () => {
+      for (let i = 0; i < MAX_STACK_SIZE + 1; i++) stack.push(makeEntry(i));
+      expect(stack.size()).toBe(MAX_STACK_SIZE);
+    });
+
+    test('11件 push 後に peek は最後のエントリを返す', () => {
+      for (let i = 0; i < MAX_STACK_SIZE + 1; i++) stack.push(makeEntry(i));
+      expect(stack.peek().recordId).toBe(`id${MAX_STACK_SIZE}`);
+    });
+
+    test('11件 push 後に id0 (最古) は消えている', () => {
+      for (let i = 0; i < MAX_STACK_SIZE + 1; i++) stack.push(makeEntry(i));
+      const ids = [];
+      let e;
+      while ((e = stack.pop()) !== null) ids.push(e.recordId);
+      expect(ids).not.toContain('id0');
+    });
+  });
+
+  // ── pop ─────────────────────────────────────────────────────────────────
+  describe('pop()', () => {
+    test('LIFO 順に返す', () => {
+      const e1 = makeEntry(1);
+      const e2 = makeEntry(2);
+      stack.push(e1);
+      stack.push(e2);
+      expect(stack.pop()).toBe(e2);
+      expect(stack.pop()).toBe(e1);
+    });
+
+    test('空のスタックから pop すると null を返す', () => {
+      expect(stack.pop()).toBeNull();
+    });
+
+    test('pop 後に size が減る', () => {
+      stack.push(makeEntry(1));
+      stack.push(makeEntry(2));
+      stack.pop();
+      expect(stack.size()).toBe(1);
+    });
+
+    test('全て pop した後は isEmpty=true', () => {
+      stack.push(makeEntry(1));
+      stack.pop();
+      expect(stack.isEmpty()).toBe(true);
+    });
+  });
+
+  // ── peek ────────────────────────────────────────────────────────────────
+  describe('peek()', () => {
+    test('最新エントリを返す（削除しない）', () => {
+      const entry = makeEntry(1);
+      stack.push(entry);
+      expect(stack.peek()).toBe(entry);
+      expect(stack.size()).toBe(1);
+    });
+
+    test('空のスタックの peek は null を返す', () => {
+      expect(stack.peek()).toBeNull();
+    });
+
+    test('peek を何度呼んでも size は変わらない', () => {
+      stack.push(makeEntry(1));
+      stack.peek();
+      stack.peek();
+      expect(stack.size()).toBe(1);
+    });
+  });
+
+  // ── clear ─────────────────────────────────────────────────────────────
+  describe('clear()', () => {
+    test('clear 後は isEmpty=true, size=0', () => {
+      stack.push(makeEntry(1));
+      stack.push(makeEntry(2));
+      stack.clear();
+      expect(stack.isEmpty()).toBe(true);
+      expect(stack.size()).toBe(0);
+    });
+
+    test('clear 後に pop すると null を返す', () => {
+      stack.push(makeEntry(1));
+      stack.clear();
+      expect(stack.pop()).toBeNull();
+    });
+
+    test('clear 後に再度 push できる', () => {
+      stack.push(makeEntry(1));
+      stack.clear();
+      stack.push(makeEntry(2));
+      expect(stack.size()).toBe(1);
+      expect(stack.peek().recordId).toBe('id2');
+    });
+  });
+});

--- a/lib/undoStack.js
+++ b/lib/undoStack.js
@@ -1,2 +1,64 @@
-// Step 11（feature/step11-update-safety）で実装する
+'use strict';
+
+// lib/undoStack.js
 // update 前の値を最大10件 LIFO 保持・復元
+
+const MAX_STACK_SIZE = 10;
+
+/**
+ * LIFO undo stack を生成する
+ * @returns {{ push, pop, peek, clear, size, isEmpty }}
+ */
+function createUndoStack() {
+  const stack = [];
+
+  /**
+   * エントリをスタックに追加する
+   * MAX_STACK_SIZE を超えた場合は最古のエントリを削除する
+   * @param {{ objectName: string, recordId: string, previousFields: object, updatedFields: object, timestamp: number }} entry
+   */
+  function push(entry) {
+    if (!entry || typeof entry !== 'object') return;
+    stack.push(entry);
+    if (stack.length > MAX_STACK_SIZE) {
+      stack.shift();
+    }
+  }
+
+  /**
+   * スタックの先頭（最新）エントリを取り出して削除する
+   * @returns {object|null}
+   */
+  function pop() {
+    return stack.length > 0 ? stack.pop() : null;
+  }
+
+  /**
+   * スタックの先頭（最新）エントリを削除せずに返す
+   * @returns {object|null}
+   */
+  function peek() {
+    return stack.length > 0 ? stack[stack.length - 1] : null;
+  }
+
+  /** スタックを全削除する */
+  function clear() {
+    stack.length = 0;
+  }
+
+  /** スタックの現在の件数を返す */
+  function size() {
+    return stack.length;
+  }
+
+  /** スタックが空かどうかを返す */
+  function isEmpty() {
+    return stack.length === 0;
+  }
+
+  return { push, pop, peek, clear, size, isEmpty };
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { createUndoStack, MAX_STACK_SIZE };
+}


### PR DESCRIPTION
## 概要\n\nIssue #10 の対応。`lib/undoStack.js` を TDD で実装し、更新安全フローの統合テストを追加。\n\n## 実装内容\n\n### `lib/undoStack.js`\n- `MAX_STACK_SIZE = 10`\n- `createUndoStack()` — LIFO スタックを返す\n  - `push(entry)` — エントリ追加（10件超えで最古を削除）\n  - `pop()` — 先頭を取り出して削除（空なら null）\n  - `peek()` — 先頭を参照（削除しない）\n  - `clear()` — 全削除\n  - `size()` / `isEmpty()`\n\n### エントリ構造\n```js\n{\n  objectName:     'Opportunity',\n  recordId:       'opp001',\n  previousFields: { Amount: 3000000 },\n  updatedFields:  { Amount: 5000000 },\n  timestamp:      Date.now()\n}\n```\n\n## テスト\n\n| ファイル | 件数 |\n|---------|------|\n| `__tests__/unit/undoStack.test.js` | 22件 |\n| `__tests__/integration/updateSafety.test.js` | 9件 |\n\n### 統合テストカバー範囲\n- `getRecord` → push → undo（pop → `updateRecord`）フロー\n- LIFO 順の複数 undo\n- `LastModifiedDate` 競合検知（一致 / 不一致 / `currentLastModifiedDate` 伝播）\n- expectedLastModifiedDate なしの場合は競合チェックをスキップ\n- 11件超え時の上限動作\n\n## Closes\n\nCloses #10