### PR TITLE
feat(error-handling): Step 13 エラーハンドリング統合実装（TDD） (#12)

### DIFF
--- a/__tests__/integration/freePlanLimit.test.js
+++ b/__tests__/integration/freePlanLimit.test.js
@@ -1,0 +1,225 @@
+'use strict';
+
+const { classifyError, showError, ERROR_CATEGORY } = require('../../lib/errorHandler');
+const { resolveIntent } = require('../../lib/intentResolver');
+
+describe('エラーハンドリング統合テスト', () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  // ── Worker 429: 利用制限超過 ─────────────────────────────────────────────
+  describe('Worker 429 (利用制限超過)', () => {
+    test('classifyError: status 429 → FREE_PLAN_LIMIT カテゴリ', () => {
+      const err = new Error('Daily limit exceeded');
+      err.status = 429;
+
+      const result = classifyError(err);
+      expect(result.category).toBe(ERROR_CATEGORY.FREE_PLAN_LIMIT);
+      expect(result.message).toContain('利用制限');
+    });
+
+    test('resolveIntent が 429 を受け取ると error.status = 429 でスローする', async () => {
+      global.fetch.mockResolvedValue({
+        ok: false,
+        status: 429,
+        json: async () => ({ error: 'Daily limit exceeded' }),
+      });
+
+      await expect(
+        resolveIntent('商談一覧', '', 'https://worker.example.com', 'user1')
+      ).rejects.toMatchObject({ status: 429 });
+    });
+
+    test('resolveIntent 429 → classifyError → FREE_PLAN_LIMIT', async () => {
+      global.fetch.mockResolvedValue({
+        ok: false,
+        status: 429,
+        json: async () => ({ error: 'Daily limit exceeded' }),
+      });
+
+      let caught;
+      try {
+        await resolveIntent('商談一覧', '', 'https://worker.example.com', 'user1');
+      } catch (e) {
+        caught = e;
+      }
+
+      const result = classifyError(caught);
+      expect(result.category).toBe(ERROR_CATEGORY.FREE_PLAN_LIMIT);
+    });
+
+    test('resolveIntent 429 → showError → widget に利用制限メッセージが表示される', async () => {
+      global.fetch.mockResolvedValue({
+        ok: false,
+        status: 429,
+        json: async () => ({ error: 'Daily limit exceeded' }),
+      });
+
+      const mockWidget = { setState: jest.fn() };
+      let caught;
+      try {
+        await resolveIntent('商談一覧', '', 'https://worker.example.com', 'user1');
+      } catch (e) {
+        caught = e;
+      }
+
+      showError(mockWidget, caught);
+      expect(mockWidget.setState).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ message: expect.stringContaining('利用制限') })
+      );
+    });
+  });
+
+  // ── Worker 502: LLM サービス一時停止 ────────────────────────────────────
+  describe('Worker 502 (音声解析サービス一時停止)', () => {
+    test('resolveIntent 502 → classifyError → SERVER_ERROR + 音声解析メッセージ', async () => {
+      global.fetch.mockResolvedValue({
+        ok: false,
+        status: 502,
+        json: async () => ({ error: 'Bad Gateway' }),
+      });
+
+      let caught;
+      try {
+        await resolveIntent('商談を作成', '', 'https://worker.example.com', 'user1');
+      } catch (e) {
+        caught = e;
+      }
+
+      const result = classifyError(caught);
+      expect(result.category).toBe(ERROR_CATEGORY.SERVER_ERROR);
+      expect(result.message).toContain('音声解析');
+    });
+
+    test('resolveIntent 503 → classifyError → SERVER_ERROR', async () => {
+      global.fetch.mockResolvedValue({
+        ok: false,
+        status: 503,
+        json: async () => ({ error: 'Service Unavailable' }),
+      });
+
+      let caught;
+      try {
+        await resolveIntent('商談を作成', '', 'https://worker.example.com', 'user1');
+      } catch (e) {
+        caught = e;
+      }
+
+      const result = classifyError(caught);
+      expect(result.category).toBe(ERROR_CATEGORY.SERVER_ERROR);
+    });
+  });
+
+  // ── ネットワーク切断 ─────────────────────────────────────────────────────
+  describe('ネットワーク切断 (TypeError)', () => {
+    test('fetch TypeError → classifyError → NETWORK カテゴリ', async () => {
+      global.fetch.mockRejectedValue(new TypeError('Failed to fetch'));
+
+      let caught;
+      try {
+        await resolveIntent('商談一覧', '', 'https://worker.example.com', 'user1');
+      } catch (e) {
+        caught = e;
+      }
+
+      const result = classifyError(caught);
+      expect(result.category).toBe(ERROR_CATEGORY.NETWORK);
+      expect(result.message).toContain('ネットワーク');
+    });
+
+    test('fetch TypeError → showError → widget にネットワークエラーメッセージが表示される', async () => {
+      global.fetch.mockRejectedValue(new TypeError('Failed to fetch'));
+
+      const mockWidget = { setState: jest.fn() };
+      let caught;
+      try {
+        await resolveIntent('商談一覧', '', 'https://worker.example.com', 'user1');
+      } catch (e) {
+        caught = e;
+      }
+
+      showError(mockWidget, caught);
+      expect(mockWidget.setState).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ message: expect.stringContaining('ネットワーク') })
+      );
+    });
+  });
+
+  // ── Salesforce API エラー統合 ────────────────────────────────────────────
+  describe('Salesforce API エラー統合', () => {
+    test('TOKEN_EXPIRED → showError → 再ログインメッセージ', () => {
+      const sfError = new Error('Session expired');
+      sfError.code = 'TOKEN_EXPIRED';
+      const mockWidget = { setState: jest.fn() };
+
+      showError(mockWidget, sfError);
+
+      expect(mockWidget.setState).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ message: expect.stringContaining('再度ログイン') })
+      );
+    });
+
+    test('CONFLICT → classifyError → CONFLICT カテゴリ + 競合メッセージ', () => {
+      const sfError = new Error('Conflict');
+      sfError.code = 'CONFLICT';
+
+      const result = classifyError(sfError);
+      expect(result.category).toBe(ERROR_CATEGORY.CONFLICT);
+      expect(result.message).toContain('別のユーザー');
+    });
+
+    test('PERMISSION_DENIED → showError → アクセス権限メッセージ', () => {
+      const sfError = new Error('Forbidden');
+      sfError.code = 'PERMISSION_DENIED';
+      const mockWidget = { setState: jest.fn() };
+
+      showError(mockWidget, sfError);
+
+      expect(mockWidget.setState).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ message: expect.stringContaining('アクセス権限') })
+      );
+    });
+  });
+
+  // ── 音声認識エラー統合 ───────────────────────────────────────────────────
+  describe('音声認識エラー統合', () => {
+    test('"no-speech" → showError → 音声未検出メッセージ', () => {
+      const mockWidget = { setState: jest.fn() };
+      showError(mockWidget, 'no-speech');
+
+      expect(mockWidget.setState).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ message: expect.stringContaining('音声が検出されませんでした') })
+      );
+    });
+
+    test('"not-allowed" → showError → マイク許可メッセージ', () => {
+      const mockWidget = { setState: jest.fn() };
+      showError(mockWidget, 'not-allowed');
+
+      expect(mockWidget.setState).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ message: expect.stringContaining('マイク') })
+      );
+    });
+
+    test('"audio-capture" → showError → マイク未接続メッセージ', () => {
+      const mockWidget = { setState: jest.fn() };
+      showError(mockWidget, 'audio-capture');
+
+      expect(mockWidget.setState).toHaveBeenCalledWith(
+        'error',
+        expect.objectContaining({ message: expect.stringContaining('マイクが見つかりません') })
+      );
+    });
+  });
+});

--- a/__tests__/unit/errorHandler.test.js
+++ b/__tests__/unit/errorHandler.test.js
@@ -1,0 +1,227 @@
+'use strict';
+
+const {
+  classifyError,
+  showError,
+  ERROR_CATEGORY,
+  SPEECH_ERROR_MESSAGES,
+} = require('../../lib/errorHandler');
+
+describe('classifyError', () => {
+  // ── null / undefined ──────────────────────────────────────────────────────
+  describe('null / undefined 入力', () => {
+    test('null → UNKNOWN カテゴリ', () => {
+      const result = classifyError(null);
+      expect(result.category).toBe(ERROR_CATEGORY.UNKNOWN);
+      expect(result.message).toBeTruthy();
+    });
+
+    test('undefined → UNKNOWN カテゴリ', () => {
+      const result = classifyError(undefined);
+      expect(result.category).toBe(ERROR_CATEGORY.UNKNOWN);
+      expect(result.message).toBeTruthy();
+    });
+  });
+
+  // ── 音声認識エラー（文字列）────────────────────────────────────────────
+  describe('音声認識エラー (string)', () => {
+    test.each(Object.keys(SPEECH_ERROR_MESSAGES))(
+      '既知コード "%s" → SPEECH カテゴリ + 対応メッセージ',
+      (code) => {
+        const result = classifyError(code);
+        expect(result.category).toBe(ERROR_CATEGORY.SPEECH);
+        expect(result.message).toBe(SPEECH_ERROR_MESSAGES[code]);
+      }
+    );
+
+    test('未知コード → SPEECH カテゴリ + フォールバックメッセージ', () => {
+      const result = classifyError('some-unknown-speech-error');
+      expect(result.category).toBe(ERROR_CATEGORY.SPEECH);
+      expect(result.message).toBeTruthy();
+    });
+  });
+
+  // ── TypeError (fetch 失敗)────────────────────────────────────────────────
+  describe('TypeError (ネットワーク切断)', () => {
+    test('TypeError → NETWORK カテゴリ', () => {
+      const result = classifyError(new TypeError('Failed to fetch'));
+      expect(result.category).toBe(ERROR_CATEGORY.NETWORK);
+      expect(result.message).toContain('ネットワーク');
+    });
+
+    test('TypeError のメッセージによらず NETWORK カテゴリ', () => {
+      const result = classifyError(new TypeError('NetworkError when attempting to fetch resource'));
+      expect(result.category).toBe(ERROR_CATEGORY.NETWORK);
+    });
+  });
+
+  // ── Salesforce API エラーコード ──────────────────────────────────────────
+  describe('Salesforce API エラーコード', () => {
+    test('TOKEN_EXPIRED → AUTH カテゴリ', () => {
+      const err = new Error();
+      err.code = 'TOKEN_EXPIRED';
+      const result = classifyError(err);
+      expect(result.category).toBe(ERROR_CATEGORY.AUTH);
+      expect(result.message).toContain('再度ログイン');
+    });
+
+    test('PERMISSION_DENIED → PERMISSION カテゴリ', () => {
+      const err = new Error();
+      err.code = 'PERMISSION_DENIED';
+      const result = classifyError(err);
+      expect(result.category).toBe(ERROR_CATEGORY.PERMISSION);
+      expect(result.message).toContain('アクセス権限');
+    });
+
+    test('RATE_LIMITED → RATE_LIMIT カテゴリ', () => {
+      const err = new Error();
+      err.code = 'RATE_LIMITED';
+      const result = classifyError(err);
+      expect(result.category).toBe(ERROR_CATEGORY.RATE_LIMIT);
+      expect(result.message).toContain('上限');
+    });
+
+    test('CONFLICT → CONFLICT カテゴリ', () => {
+      const err = new Error();
+      err.code = 'CONFLICT';
+      const result = classifyError(err);
+      expect(result.category).toBe(ERROR_CATEGORY.CONFLICT);
+      expect(result.message).toContain('別のユーザー');
+    });
+
+    test('NOT_FOUND → NOT_FOUND カテゴリ', () => {
+      const err = new Error();
+      err.code = 'NOT_FOUND';
+      const result = classifyError(err);
+      expect(result.category).toBe(ERROR_CATEGORY.NOT_FOUND);
+      expect(result.message).toContain('見つかりません');
+    });
+
+    test('SERVER_ERROR → SERVER_ERROR カテゴリ', () => {
+      const err = new Error();
+      err.code = 'SERVER_ERROR';
+      const result = classifyError(err);
+      expect(result.category).toBe(ERROR_CATEGORY.SERVER_ERROR);
+      expect(result.message).toContain('サーバーエラー');
+    });
+  });
+
+  // ── Worker HTTP ステータスエラー ─────────────────────────────────────────
+  describe('Cloudflare Worker HTTP ステータスエラー', () => {
+    test('status 429 → FREE_PLAN_LIMIT カテゴリ', () => {
+      const err = new Error('Limit exceeded');
+      err.status = 429;
+      const result = classifyError(err);
+      expect(result.category).toBe(ERROR_CATEGORY.FREE_PLAN_LIMIT);
+      expect(result.message).toContain('利用制限');
+    });
+
+    test('status 401 → AUTH カテゴリ', () => {
+      const err = new Error('Unauthorized');
+      err.status = 401;
+      const result = classifyError(err);
+      expect(result.category).toBe(ERROR_CATEGORY.AUTH);
+      expect(result.message).toContain('再度ログイン');
+    });
+
+    test('status 502 → SERVER_ERROR カテゴリ', () => {
+      const err = new Error('Bad Gateway');
+      err.status = 502;
+      const result = classifyError(err);
+      expect(result.category).toBe(ERROR_CATEGORY.SERVER_ERROR);
+      expect(result.message).toContain('音声解析');
+    });
+
+    test('status 503 → SERVER_ERROR カテゴリ', () => {
+      const err = new Error('Service Unavailable');
+      err.status = 503;
+      const result = classifyError(err);
+      expect(result.category).toBe(ERROR_CATEGORY.SERVER_ERROR);
+      expect(result.message).toContain('音声解析');
+    });
+  });
+
+  // ── 汎用ネットワークエラー（メッセージ文字列マッチ）──────────────────
+  describe('汎用ネットワークエラー（メッセージマッチ）', () => {
+    test('"Failed to fetch" → NETWORK カテゴリ', () => {
+      const err = new Error('Failed to fetch');
+      const result = classifyError(err);
+      expect(result.category).toBe(ERROR_CATEGORY.NETWORK);
+    });
+
+    test('"network error" → NETWORK カテゴリ', () => {
+      const err = new Error('network error occurred');
+      const result = classifyError(err);
+      expect(result.category).toBe(ERROR_CATEGORY.NETWORK);
+    });
+
+    test('大文字小文字を区別しない', () => {
+      const err = new Error('Network Error');
+      const result = classifyError(err);
+      expect(result.category).toBe(ERROR_CATEGORY.NETWORK);
+    });
+  });
+
+  // ── 未知エラー ────────────────────────────────────────────────────────
+  describe('未知エラー', () => {
+    test('不明メッセージ → UNKNOWN カテゴリ + error.message を返す', () => {
+      const err = new Error('Something unexpected happened');
+      const result = classifyError(err);
+      expect(result.category).toBe(ERROR_CATEGORY.UNKNOWN);
+      expect(result.message).toBe('Something unexpected happened');
+    });
+
+    test('メッセージなし Error → UNKNOWN カテゴリ + デフォルトメッセージ', () => {
+      const err = new Error();
+      const result = classifyError(err);
+      expect(result.category).toBe(ERROR_CATEGORY.UNKNOWN);
+      expect(result.message).toBeTruthy();
+    });
+  });
+});
+
+// ── showError ──────────────────────────────────────────────────────────────
+describe('showError', () => {
+  test('AUTH エラー → widget.setState("error") + 再ログインメッセージ', () => {
+    const mockWidget = { setState: jest.fn() };
+    const err = new Error();
+    err.code = 'TOKEN_EXPIRED';
+
+    showError(mockWidget, err);
+
+    expect(mockWidget.setState).toHaveBeenCalledWith(
+      'error',
+      expect.objectContaining({ message: expect.stringContaining('再度ログイン') })
+    );
+  });
+
+  test('音声エラー文字列 → widget.setState("error") + 該当メッセージ', () => {
+    const mockWidget = { setState: jest.fn() };
+
+    showError(mockWidget, 'no-speech');
+
+    expect(mockWidget.setState).toHaveBeenCalledWith(
+      'error',
+      expect.objectContaining({ message: SPEECH_ERROR_MESSAGES['no-speech'] })
+    );
+  });
+
+  test('TypeError → widget.setState("error") + ネットワークメッセージ', () => {
+    const mockWidget = { setState: jest.fn() };
+
+    showError(mockWidget, new TypeError('Failed to fetch'));
+
+    expect(mockWidget.setState).toHaveBeenCalledWith(
+      'error',
+      expect.objectContaining({ message: expect.stringContaining('ネットワーク') })
+    );
+  });
+
+  test('null → widget.setState("error") + デフォルトメッセージ', () => {
+    const mockWidget = { setState: jest.fn() };
+
+    showError(mockWidget, null);
+
+    expect(mockWidget.setState).toHaveBeenCalledWith('error', expect.objectContaining({ message: expect.any(String) }));
+  });
+});

--- a/lib/errorHandler.js
+++ b/lib/errorHandler.js
@@ -1,0 +1,115 @@
+'use strict';
+
+// lib/errorHandler.js
+// 全モジュールのエラーを統一分類し、日本語ユーザーメッセージを返す
+
+const ERROR_CATEGORY = {
+  NETWORK:        'network',
+  AUTH:           'auth',
+  PERMISSION:     'permission',
+  RATE_LIMIT:     'rate_limit',
+  FREE_PLAN_LIMIT:'free_plan_limit',
+  CONFLICT:       'conflict',
+  NOT_FOUND:      'not_found',
+  SERVER_ERROR:   'server_error',
+  SPEECH:         'speech',
+  VALIDATION:     'validation',
+  UNKNOWN:        'unknown',
+};
+
+// Web Speech API の onerror イベントで渡される error 文字列 → ユーザーメッセージ
+const SPEECH_ERROR_MESSAGES = {
+  'no-speech':              '音声が検出されませんでした。もう一度お試しください。',
+  'not-allowed':            'マイクへのアクセスが許可されていません。設定を確認してください。',
+  'audio-capture':          'マイクが見つかりません。接続を確認してください。',
+  'network':                '音声認識のネットワークエラーが発生しました。',
+  'aborted':                '音声認識が中断されました。',
+  'language-not-supported': '言語設定がサポートされていません。',
+  'service-not-allowed':    '音声認識サービスへのアクセスが許可されていません。',
+};
+
+// salesforceApi.js の SF_ERROR_CODES → ユーザーメッセージ
+const SF_CODE_RESULTS = {
+  TOKEN_EXPIRED:     { category: ERROR_CATEGORY.AUTH,         message: '認証の有効期限が切れています。再度ログインしてください。' },
+  PERMISSION_DENIED: { category: ERROR_CATEGORY.PERMISSION,   message: 'このレコードへのアクセス権限がありません。' },
+  RATE_LIMITED:      { category: ERROR_CATEGORY.RATE_LIMIT,   message: 'リクエスト数の上限に達しました。しばらく待ってから再試行してください。' },
+  CONFLICT:          { category: ERROR_CATEGORY.CONFLICT,     message: 'レコードが別のユーザーによって更新されています。' },
+  NOT_FOUND:         { category: ERROR_CATEGORY.NOT_FOUND,    message: 'レコードが見つかりません。' },
+  SERVER_ERROR:      { category: ERROR_CATEGORY.SERVER_ERROR, message: 'Salesforceサーバーエラーが発生しました。しばらく待ってから再試行してください。' },
+};
+
+const NETWORK_ERROR_MESSAGE = 'ネットワークエラーが発生しました。インターネット接続を確認してください。';
+const DEFAULT_ERROR_MESSAGE  = '予期しないエラーが発生しました。もう一度お試しください。';
+
+/**
+ * エラーを分類し、ユーザー向けカテゴリとメッセージを返す
+ *
+ * 分類優先度:
+ *   1. null/undefined → UNKNOWN
+ *   2. string         → SPEECH（Web Speech API エラーコード）
+ *   3. TypeError      → NETWORK（fetch 失敗）
+ *   4. error.code     → Salesforce API エラー
+ *   5. error.status   → Cloudflare Worker HTTP ステータスエラー
+ *   6. error.message  → 汎用ネットワークエラー文字列マッチ
+ *   7. その他         → UNKNOWN
+ *
+ * @param {Error|string|null} error
+ * @returns {{ category: string, message: string }}
+ */
+function classifyError(error) {
+  if (!error) {
+    return { category: ERROR_CATEGORY.UNKNOWN, message: DEFAULT_ERROR_MESSAGE };
+  }
+
+  // 音声認識エラー（Web Speech API が onerror に渡す文字列）
+  if (typeof error === 'string') {
+    return {
+      category: ERROR_CATEGORY.SPEECH,
+      message:  SPEECH_ERROR_MESSAGES[error] || '音声認識エラーが発生しました。',
+    };
+  }
+
+  // ネットワーク切断 (fetch が TypeError をスロー)
+  if (error instanceof TypeError) {
+    return { category: ERROR_CATEGORY.NETWORK, message: NETWORK_ERROR_MESSAGE };
+  }
+
+  // Salesforce API エラーコード (salesforceApi.js の handleResponse がセット)
+  if (error.code && SF_CODE_RESULTS[error.code]) {
+    return SF_CODE_RESULTS[error.code];
+  }
+
+  // Cloudflare Worker の HTTP ステータスエラー (intentResolver.js がセット)
+  if (typeof error.status === 'number') {
+    if (error.status === 429) {
+      return { category: ERROR_CATEGORY.FREE_PLAN_LIMIT, message: '本日の利用制限に達しました。明日以降にお試しください。' };
+    }
+    if (error.status === 401) {
+      return { category: ERROR_CATEGORY.AUTH, message: '認証の有効期限が切れています。再度ログインしてください。' };
+    }
+    if (error.status === 502 || error.status === 503) {
+      return { category: ERROR_CATEGORY.SERVER_ERROR, message: '音声解析サービスが一時的に利用できません。しばらく待ってから再試行してください。' };
+    }
+  }
+
+  // 汎用ネットワークエラー（メッセージ文字列マッチ）
+  if (error.message && /failed to fetch|network error/i.test(error.message)) {
+    return { category: ERROR_CATEGORY.NETWORK, message: NETWORK_ERROR_MESSAGE };
+  }
+
+  return { category: ERROR_CATEGORY.UNKNOWN, message: error.message || DEFAULT_ERROR_MESSAGE };
+}
+
+/**
+ * エラーを分類してウィジェットにエラー状態をセットする
+ * @param {{ setState: function }} widget - createWidget() が返すオブジェクト
+ * @param {Error|string|null} error
+ */
+function showError(widget, error) {
+  const { message } = classifyError(error);
+  widget.setState('error', { message });
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { classifyError, showError, ERROR_CATEGORY, SPEECH_ERROR_MESSAGES };
+}


### PR DESCRIPTION
## Summary\n\n- `lib/errorHandler.js` を新規実装\n  - `classifyError(error)` — エラーを7段階の優先度で分類し、日本語ユーザーメッセージを返す\n  - `showError(widget, error)` — エラー分類結果をウィジェットのERROR状態にセット\n  - `ERROR_CATEGORY` 定数（NETWORK / AUTH / PERMISSION / RATE_LIMIT / FREE_PLAN_LIMIT / CONFLICT / NOT_FOUND / SERVER_ERROR / SPEECH / VALIDATION / UNKNOWN）\n- 対応エラー源: Web Speech API（文字列）/ TypeError（fetch失敗）/ Salesforce API（error.code）/ Cloudflare Worker（error.status）/ 汎用メッセージマッチ\n- `__tests__/unit/errorHandler.test.js`（28テスト）を追加\n- `__tests__/integration/freePlanLimit.test.js`（13テスト）を追加\n  - Worker 429（利用制限）/ 502・503（サービス停止）/ TypeError（ネットワーク切断）/ SF API エラー / 音声認識エラーの統合フロー検証\n\n## Test plan\n\n- [ ] `npx jest __tests__/unit/errorHandler.test.js` — ユニットテスト全通過\n- [ ] `npx jest __tests__/integration/freePlanLimit.test.js` — 統合テスト全通過\n- [ ] `npm test` — 全テストスイート通過\n\nCloses #12\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)