### PR TITLE
fix(popup): コンシューマーキー・シークレット入力欄を復元 (#36)

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -61,6 +61,32 @@
       margin-top: 16px;
     }
 
+    label {
+      display: block;
+      font-size: 12px;
+      font-weight: 500;
+      color: #374151;
+      margin-bottom: 4px;
+    }
+
+    input[type="text"],
+    input[type="password"] {
+      width: 100%;
+      padding: 7px 10px;
+      border: 1px solid #d1d5db;
+      border-radius: 6px;
+      font-size: 13px;
+      box-sizing: border-box;
+      margin-bottom: 10px;
+      outline: none;
+      transition: border-color 0.15s;
+    }
+
+    input[type="text"]:focus,
+    input[type="password"]:focus {
+      border-color: #0066cc;
+    }
+
     button {
       width: 100%;
       padding: 8px 16px;
@@ -143,9 +169,21 @@
     <div id="instance-url" class="instance-url" style="display:none;"></div>
   </div>
 
-  <div class="section">
+  <div id="connect-form" class="section">
+    <label for="client-id-input">コンシューマーキー</label>
+    <input type="text" id="client-id-input" placeholder="Connected App のコンシューマーキー">
+
+    <label for="client-secret-input">コンシューマーシークレット</label>
+    <input type="password" id="client-secret-input" placeholder="コンシューマーシークレット">
+
+    <label for="instance-url-input">Salesforce URL</label>
+    <input type="text" id="instance-url-input" value="https://login.salesforce.com" placeholder="https://login.salesforce.com">
+
     <button id="connect-btn" class="btn-primary">Salesforceに接続</button>
-    <button id="disconnect-btn" class="btn-danger" style="display:none;">接続を解除</button>
+  </div>
+
+  <div id="disconnect-section" class="section" style="display:none;">
+    <button id="disconnect-btn" class="btn-danger">接続を解除</button>
   </div>
 
   <div class="shortcut-section">

--- a/popup.js
+++ b/popup.js
@@ -3,27 +3,32 @@
 const statusBadge = document.getElementById('status-badge');
 const statusText = document.getElementById('status-text');
 const instanceUrlEl = document.getElementById('instance-url');
+const connectForm = document.getElementById('connect-form');
+const disconnectSection = document.getElementById('disconnect-section');
 const connectBtn = document.getElementById('connect-btn');
 const disconnectBtn = document.getElementById('disconnect-btn');
+const clientIdInput = document.getElementById('client-id-input');
+const clientSecretInput = document.getElementById('client-secret-input');
+const instanceUrlInput = document.getElementById('instance-url-input');
 
-async function updateUI(isConnected, instanceUrl) {
+function updateUI(isConnected, instanceUrl) {
   if (isConnected) {
     statusBadge.className = 'status-badge connected';
     statusText.textContent = '接続済み';
     instanceUrlEl.textContent = instanceUrl || '';
     instanceUrlEl.style.display = instanceUrl ? 'block' : 'none';
-    connectBtn.style.display = 'none';
-    disconnectBtn.style.display = 'block';
+    connectForm.style.display = 'none';
+    disconnectSection.style.display = 'block';
   } else {
     statusBadge.className = 'status-badge disconnected';
     statusText.textContent = '未接続';
     instanceUrlEl.style.display = 'none';
-    connectBtn.style.display = 'block';
-    disconnectBtn.style.display = 'none';
+    connectForm.style.display = 'block';
+    disconnectSection.style.display = 'none';
   }
 }
 
-async function loadStatus() {
+function loadStatus() {
   chrome.storage.local.get(['instance_url'], (result) => {
     const isConnected = !!result.instance_url;
     updateUI(isConnected, result.instance_url);
@@ -31,7 +36,29 @@ async function loadStatus() {
 }
 
 connectBtn.addEventListener('click', () => {
-  chrome.runtime.sendMessage({ type: 'CONNECT_SALESFORCE' });
+  const clientId = clientIdInput.value.trim();
+  const clientSecret = clientSecretInput.value.trim();
+  const instanceUrl = instanceUrlInput.value.trim() || 'https://login.salesforce.com';
+
+  // バリデーション
+  if (!clientId) {
+    clientIdInput.style.borderColor = 'rgb(239, 68, 68)';
+    clientIdInput.focus();
+    return;
+  }
+  clientIdInput.style.borderColor = '';
+
+  chrome.runtime.sendMessage(
+    { type: 'CONNECT_SALESFORCE', clientId, clientSecret, instanceUrl },
+    (response) => {
+      if (response && response.success) {
+        loadStatus();
+      } else {
+        const err = response && response.error ? response.error : '接続に失敗しました';
+        statusText.textContent = `エラー: ${err}`;
+      }
+    }
+  );
 });
 
 disconnectBtn.addEventListener('click', () => {


### PR DESCRIPTION
## 問題\n\npopup.html・popup.js がスタブ版（入力欄なし）に戻っており、未接続状態から OAuth 接続できなかった。\n\n## 修正内容\n\n### popup.html\n- コンシューマーキー入力欄 `#client-id-input` を追加\n- コンシューマーシークレット入力欄 `#client-secret-input` を追加\n- Salesforce URL 入力欄 `#instance-url-input`（初期値: https://login.salesforce.com）を追加\n- `#connect-form` / `#disconnect-section` で接続状態に応じて表示切替\n\n### popup.js\n- 入力値を読み取って `CONNECT_SALESFORCE` メッセージに `clientId`, `clientSecret`, `instanceUrl` を含めて送信\n- コンシューマーキー未入力時にバリデーションエラー表示