### PR TITLE
fix(auth): PKCE + clientSecret を OAuth フローに追加（認可ページ読み込みエラー修正）

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -172,18 +172,24 @@ async function saveTokens(accessToken, refreshToken, instanceUrl, expiresIn, cli
  * @param {string} instanceUrl
  * @param {string} clientId
  * @param {string} redirectUri
+ * @param {string} [clientSecret]
+ * @param {string} [codeVerifier] - PKCE code verifier
  * @returns {Promise<object>} トークンレスポンス
  */
-async function exchangeCodeForTokens(code, instanceUrl, clientId, redirectUri) {
+async function exchangeCodeForTokens(code, instanceUrl, clientId, redirectUri, clientSecret, codeVerifier) {
+  const params = {
+    grant_type: 'authorization_code',
+    code,
+    client_id: clientId,
+    redirect_uri: redirectUri,
+  };
+  if (clientSecret) params.client_secret = clientSecret;
+  if (codeVerifier) params.code_verifier = codeVerifier;
+
   const response = await fetch(`${instanceUrl}/services/oauth2/token`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      grant_type: 'authorization_code',
-      code,
-      client_id: clientId,
-      redirect_uri: redirectUri,
-    }),
+    body: new URLSearchParams(params),
   });
 
   if (!response.ok) {
@@ -195,11 +201,12 @@ async function exchangeCodeForTokens(code, instanceUrl, clientId, redirectUri) {
 }
 
 /**
- * Salesforce OAuth 2.0 Authorization Code Flow を開始する
+ * Salesforce OAuth 2.0 Authorization Code Flow + PKCE を開始する
  * @param {string} clientId - Salesforce Connected App の Consumer Key
  * @param {string} instanceUrl - ログイン URL（デフォルト: https://login.salesforce.com）
+ * @param {string} [clientSecret] - コンシューマーシークレット（外部クライアントアプリ用）
  */
-async function startOAuth(clientId, instanceUrl = 'https://login.salesforce.com') {
+async function startOAuth(clientId, instanceUrl = 'https://login.salesforce.com', clientSecret) {
   // Fix 2: instanceUrl のバリデーション
   if (!validateInstanceUrl(instanceUrl)) {
     throw new Error('Invalid Salesforce login URL');
@@ -209,6 +216,17 @@ async function startOAuth(clientId, instanceUrl = 'https://login.salesforce.com'
   const stateBytes = crypto.getRandomValues(new Uint8Array(16));
   const state = btoa(String.fromCharCode(...stateBytes));
 
+  // PKCE: code_verifier と code_challenge を生成
+  const codeVerifierBytes = crypto.getRandomValues(new Uint8Array(32));
+  const codeVerifier = btoa(String.fromCharCode(...codeVerifierBytes))
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+  const codeVerifierHash = await crypto.subtle.digest(
+    'SHA-256',
+    new TextEncoder().encode(codeVerifier)
+  );
+  const codeChallenge = btoa(String.fromCharCode(...new Uint8Array(codeVerifierHash)))
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+
   const authUrl =
     `${instanceUrl}/services/oauth2/authorize?` +
     new URLSearchParams({
@@ -217,6 +235,8 @@ async function startOAuth(clientId, instanceUrl = 'https://login.salesforce.com'
       redirect_uri: redirectUri,
       state,
       scope: 'api refresh_token',
+      code_challenge: codeChallenge,
+      code_challenge_method: 'S256',
     });
 
   const redirectUrl = await new Promise((resolve, reject) => {
@@ -249,7 +269,9 @@ async function startOAuth(clientId, instanceUrl = 'https://login.salesforce.com'
     throw new Error('Authorization code not found in redirect URL');
   }
 
-  const tokens = await exchangeCodeForTokens(code, instanceUrl, clientId, redirectUri);
+  const tokens = await exchangeCodeForTokens(
+    code, instanceUrl, clientId, redirectUri, clientSecret, codeVerifier
+  );
   await saveTokens(
     tokens.access_token,
     tokens.refresh_token,


### PR DESCRIPTION
## 問題\n\n`Authorization page could not be loaded.` エラーが発生し OAuth 接続ができない。\n\n## 原因\n\nSalesforce の外部クライアントアプリケーションは **PKCE 必須** だが、`startOAuth` に PKCE パラメータ（`code_challenge` / `code_challenge_method`）が含まれていなかった。また `clientSecret` がトークン交換に渡されていなかった。\n\n## 修正内容\n\n### `startOAuth`\n- PKCE `code_verifier` / `code_challenge`（S256）を生成して認可 URL に付与\n- `clientSecret` パラメータを受け取るよう引数を追加\n\n### `exchangeCodeForTokens`\n- `client_secret`（任意）と `code_verifier`（任意）をトークンリクエストに含める