### PR TITLE
fix(auth): PKCE使用時はclient_secretを送らない（invalid_client修正）

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -93,7 +93,6 @@ async function getOrCreateEncryptionKey() {
   return new Promise((resolve, reject) => {
     chrome.storage.session.get([STORAGE_KEYS.ENCRYPTION_KEY], async (result) => {
       if (result[STORAGE_KEYS.ENCRYPTION_KEY]) {
-        // 既存の鍵を復元
         try {
           const keyBytes = Uint8Array.from(
             atob(result[STORAGE_KEYS.ENCRYPTION_KEY]),
@@ -111,7 +110,6 @@ async function getOrCreateEncryptionKey() {
           reject(err);
         }
       } else {
-        // 新しい鍵を生成して保存
         try {
           const key = await generateEncryptionKey();
           const exported = await crypto.subtle.exportKey('raw', key);
@@ -140,14 +138,8 @@ async function getOrCreateEncryptionKey() {
  */
 async function saveTokens(accessToken, refreshToken, instanceUrl, expiresIn, clientId) {
   const key = await getOrCreateEncryptionKey();
-  const { iv: tokenIv, ciphertext: encryptedAccess } = await encryptString(
-    key,
-    accessToken
-  );
-  const { iv: refreshIv, ciphertext: encryptedRefresh } = await encryptString(
-    key,
-    refreshToken
-  );
+  const { iv: tokenIv, ciphertext: encryptedAccess } = await encryptString(key, accessToken);
+  const { iv: refreshIv, ciphertext: encryptedRefresh } = await encryptString(key, refreshToken);
   const tokenExpiry = Date.now() + expiresIn * 1000;
 
   return new Promise((resolve) => {
@@ -183,8 +175,13 @@ async function exchangeCodeForTokens(code, instanceUrl, clientId, redirectUri, c
     client_id: clientId,
     redirect_uri: redirectUri,
   };
-  if (clientSecret) params.client_secret = clientSecret;
-  if (codeVerifier) params.code_verifier = codeVerifier;
+  // PKCE (code_verifier) を使う場合は client_secret を送らない
+  // Salesforce 外部クライアントアプリは PKCE のみで認証するため両方送ると invalid_client になる
+  if (codeVerifier) {
+    params.code_verifier = codeVerifier;
+  } else if (clientSecret) {
+    params.client_secret = clientSecret;
+  }
 
   const response = await fetch(`${instanceUrl}/services/oauth2/token`, {
     method: 'POST',
@@ -204,10 +201,9 @@ async function exchangeCodeForTokens(code, instanceUrl, clientId, redirectUri, c
  * Salesforce OAuth 2.0 Authorization Code Flow + PKCE を開始する
  * @param {string} clientId - Salesforce Connected App の Consumer Key
  * @param {string} instanceUrl - ログイン URL（デフォルト: https://login.salesforce.com）
- * @param {string} [clientSecret] - コンシューマーシークレット（外部クライアントアプリ用）
+ * @param {string} [clientSecret] - コンシューマーシークレット（非 PKCE フロー用）
  */
 async function startOAuth(clientId, instanceUrl = 'https://login.salesforce.com', clientSecret) {
-  // Fix 2: instanceUrl のバリデーション
   if (!validateInstanceUrl(instanceUrl)) {
     throw new Error('Invalid Salesforce login URL');
   }
@@ -258,7 +254,6 @@ async function startOAuth(clientId, instanceUrl = 'https://login.salesforce.com'
 
   const url = new URL(redirectUrl);
 
-  // Fix 4: OAuth state 検証（CSRF 防止）
   const returnedState = url.searchParams.get('state');
   if (returnedState !== state) {
     throw new Error('OAuth state mismatch - possible CSRF attack');
@@ -422,7 +417,6 @@ async function getInstanceUrl() {
 }
 
 // Node.js (Jest) 環境向け CommonJS エクスポート
-// ブラウザ環境（Service Worker / Content Script）では importScripts() で読み込む
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
     generateEncryptionKey,


### PR DESCRIPTION
## 問題\n\n`Token exchange failed: invalid_client / invalid client credentials`\n\n## 原因\n\nSalesforce 外部クライアントアプリは **PKCE のみ**で認証する設計のため、`code_verifier`（PKCE）と `client_secret` を同時に送ると `invalid_client` エラーになる。\n\n## 修正\n\n`exchangeCodeForTokens` のロジックを変更：\n- `code_verifier` がある場合（PKCE フロー）→ `code_verifier` のみ送信、`client_secret` は送らない\n- `code_verifier` がない場合（非 PKCE フロー）→ `client_secret` を送信\n\nこれにより RFC 7636 の PKCE 仕様に準拠した正しいトークン交換が行われる。