### PR TITLE
fix(auth): PKCE と client_secret を両方送信（Salesforce外部クライアントアプリ対応）

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -175,13 +175,9 @@ async function exchangeCodeForTokens(code, instanceUrl, clientId, redirectUri, c
     client_id: clientId,
     redirect_uri: redirectUri,
   };
-  // PKCE (code_verifier) を使う場合は client_secret を送らない
-  // Salesforce 外部クライアントアプリは PKCE のみで認証するため両方送ると invalid_client になる
-  if (codeVerifier) {
-    params.code_verifier = codeVerifier;
-  } else if (clientSecret) {
-    params.client_secret = clientSecret;
-  }
+  // Salesforce 外部クライアントアプリは PKCE + client_secret を両方要求する
+  if (codeVerifier) params.code_verifier = codeVerifier;
+  if (clientSecret) params.client_secret = clientSecret;
 
   const response = await fetch(`${instanceUrl}/services/oauth2/token`, {
     method: 'POST',
@@ -201,7 +197,7 @@ async function exchangeCodeForTokens(code, instanceUrl, clientId, redirectUri, c
  * Salesforce OAuth 2.0 Authorization Code Flow + PKCE を開始する
  * @param {string} clientId - Salesforce Connected App の Consumer Key
  * @param {string} instanceUrl - ログイン URL（デフォルト: https://login.salesforce.com）
- * @param {string} [clientSecret] - コンシューマーシークレット（非 PKCE フロー用）
+ * @param {string} [clientSecret] - コンシューマーシークレット
  */
 async function startOAuth(clientId, instanceUrl = 'https://login.salesforce.com', clientSecret) {
   if (!validateInstanceUrl(instanceUrl)) {


### PR DESCRIPTION
## 修正\n\nSalesforce 外部クライアントアプリは PKCE（`code_verifier`）と `client_secret` を**両方**要求するため、両方を送信するよう変更。\n\n## 操作手順\n\nポップアップで**コンシューマーシークレットも必ず入力**して接続してください。