### PR TITLE
fix(auth): client_secret を HTTP Basic Auth ヘッダーで送信（RFC 6749準拠）

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -14,17 +14,9 @@ const STORAGE_KEYS = {
   ENCRYPTION_KEY: 'encryption_key',
 };
 
-// 有効期限の 5分前にリフレッシュするバッファ
 const REFRESH_BUFFER_MS = 5 * 60 * 1000;
-
-// Fix 2: Salesforce ログイン URL のみ許可
 const SALESFORCE_LOGIN_PATTERN = /^https:\/\/(login|test)\.salesforce\.com$/;
 
-/**
- * Salesforce のログイン URL として有効かどうかを検証する
- * @param {string} url
- * @returns {boolean}
- */
 function validateInstanceUrl(url) {
   if (!url || typeof url !== 'string') return false;
   try {
@@ -34,10 +26,6 @@ function validateInstanceUrl(url) {
   }
 }
 
-/**
- * AES-256-GCM 暗号化鍵を生成する
- * @returns {Promise<CryptoKey>}
- */
 async function generateEncryptionKey() {
   return crypto.subtle.generateKey(
     { name: 'AES-GCM', length: 256 },
@@ -46,12 +34,6 @@ async function generateEncryptionKey() {
   );
 }
 
-/**
- * 文字列を AES-256-GCM で暗号化する
- * @param {CryptoKey} key
- * @param {string} plaintext
- * @returns {Promise<{ iv: string, ciphertext: string }>} Base64 エンコード済み
- */
 async function encryptString(key, plaintext) {
   const iv = crypto.getRandomValues(new Uint8Array(12));
   const encoded = new TextEncoder().encode(plaintext);
@@ -66,13 +48,6 @@ async function encryptString(key, plaintext) {
   };
 }
 
-/**
- * AES-256-GCM で復号する
- * @param {CryptoKey} key
- * @param {string} ivBase64
- * @param {string} ciphertextBase64
- * @returns {Promise<string>}
- */
 async function decryptString(key, ivBase64, ciphertextBase64) {
   const iv = Uint8Array.from(atob(ivBase64), (c) => c.charCodeAt(0));
   const ciphertext = Uint8Array.from(atob(ciphertextBase64), (c) => c.charCodeAt(0));
@@ -84,11 +59,6 @@ async function decryptString(key, ivBase64, ciphertextBase64) {
   return new TextDecoder().decode(decrypted);
 }
 
-/**
- * chrome.storage.session から暗号化鍵を取得する。
- * なければ新規生成して保存する。
- * @returns {Promise<CryptoKey>}
- */
 async function getOrCreateEncryptionKey() {
   return new Promise((resolve, reject) => {
     chrome.storage.session.get([STORAGE_KEYS.ENCRYPTION_KEY], async (result) => {
@@ -99,74 +69,46 @@ async function getOrCreateEncryptionKey() {
             (c) => c.charCodeAt(0)
           );
           const key = await crypto.subtle.importKey(
-            'raw',
-            keyBytes,
-            { name: 'AES-GCM' },
-            true,
-            ['encrypt', 'decrypt']
+            'raw', keyBytes, { name: 'AES-GCM' }, true, ['encrypt', 'decrypt']
           );
           resolve(key);
-        } catch (err) {
-          reject(err);
-        }
+        } catch (err) { reject(err); }
       } else {
         try {
           const key = await generateEncryptionKey();
           const exported = await crypto.subtle.exportKey('raw', key);
-          const exportedBase64 = btoa(
-            String.fromCharCode(...new Uint8Array(exported))
-          );
+          const exportedBase64 = btoa(String.fromCharCode(...new Uint8Array(exported)));
           chrome.storage.session.set(
             { [STORAGE_KEYS.ENCRYPTION_KEY]: exportedBase64 },
             () => resolve(key)
           );
-        } catch (err) {
-          reject(err);
-        }
+        } catch (err) { reject(err); }
       }
     });
   });
 }
 
-/**
- * トークンを暗号化して chrome.storage.local に保存する
- * @param {string} accessToken
- * @param {string} refreshToken
- * @param {string} instanceUrl
- * @param {number} expiresIn - 秒単位
- * @param {string} clientId
- */
 async function saveTokens(accessToken, refreshToken, instanceUrl, expiresIn, clientId) {
   const key = await getOrCreateEncryptionKey();
   const { iv: tokenIv, ciphertext: encryptedAccess } = await encryptString(key, accessToken);
   const { iv: refreshIv, ciphertext: encryptedRefresh } = await encryptString(key, refreshToken);
   const tokenExpiry = Date.now() + expiresIn * 1000;
-
   return new Promise((resolve) => {
-    chrome.storage.local.set(
-      {
-        [STORAGE_KEYS.ENCRYPTED_ACCESS_TOKEN]: encryptedAccess,
-        [STORAGE_KEYS.ENCRYPTED_REFRESH_TOKEN]: encryptedRefresh,
-        [STORAGE_KEYS.TOKEN_IV]: tokenIv,
-        [STORAGE_KEYS.REFRESH_IV]: refreshIv,
-        [STORAGE_KEYS.INSTANCE_URL]: instanceUrl,
-        [STORAGE_KEYS.TOKEN_EXPIRY]: tokenExpiry,
-        [STORAGE_KEYS.CLIENT_ID]: clientId,
-      },
-      () => resolve()
-    );
+    chrome.storage.local.set({
+      [STORAGE_KEYS.ENCRYPTED_ACCESS_TOKEN]: encryptedAccess,
+      [STORAGE_KEYS.ENCRYPTED_REFRESH_TOKEN]: encryptedRefresh,
+      [STORAGE_KEYS.TOKEN_IV]: tokenIv,
+      [STORAGE_KEYS.REFRESH_IV]: refreshIv,
+      [STORAGE_KEYS.INSTANCE_URL]: instanceUrl,
+      [STORAGE_KEYS.TOKEN_EXPIRY]: tokenExpiry,
+      [STORAGE_KEYS.CLIENT_ID]: clientId,
+    }, () => resolve());
   });
 }
 
 /**
  * 認証コードをアクセストークンと交換する
- * @param {string} code
- * @param {string} instanceUrl
- * @param {string} clientId
- * @param {string} redirectUri
- * @param {string} [clientSecret]
- * @param {string} [codeVerifier] - PKCE code verifier
- * @returns {Promise<object>} トークンレスポンス
+ * client_secret は RFC 6749 Section 2.3.1 に従い HTTP Basic Auth ヘッダーで送信
  */
 async function exchangeCodeForTokens(code, instanceUrl, clientId, redirectUri, clientSecret, codeVerifier) {
   const params = {
@@ -175,13 +117,17 @@ async function exchangeCodeForTokens(code, instanceUrl, clientId, redirectUri, c
     client_id: clientId,
     redirect_uri: redirectUri,
   };
-  // Salesforce 外部クライアントアプリは PKCE + client_secret を両方要求する
   if (codeVerifier) params.code_verifier = codeVerifier;
-  if (clientSecret) params.client_secret = clientSecret;
+
+  const headers = { 'Content-Type': 'application/x-www-form-urlencoded' };
+  if (clientSecret) {
+    // RFC 6749 準拠の Basic Auth（clientId:clientSecret を base64 エンコード）
+    headers['Authorization'] = `Basic ${btoa(`${clientId}:${clientSecret}`)}`;
+  }
 
   const response = await fetch(`${instanceUrl}/services/oauth2/token`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    headers,
     body: new URLSearchParams(params),
   });
 
@@ -195,9 +141,6 @@ async function exchangeCodeForTokens(code, instanceUrl, clientId, redirectUri, c
 
 /**
  * Salesforce OAuth 2.0 Authorization Code Flow + PKCE を開始する
- * @param {string} clientId - Salesforce Connected App の Consumer Key
- * @param {string} instanceUrl - ログイン URL（デフォルト: https://login.salesforce.com）
- * @param {string} [clientSecret] - コンシューマーシークレット
  */
 async function startOAuth(clientId, instanceUrl = 'https://login.salesforce.com', clientSecret) {
   if (!validateInstanceUrl(instanceUrl)) {
@@ -208,13 +151,11 @@ async function startOAuth(clientId, instanceUrl = 'https://login.salesforce.com'
   const stateBytes = crypto.getRandomValues(new Uint8Array(16));
   const state = btoa(String.fromCharCode(...stateBytes));
 
-  // PKCE: code_verifier と code_challenge を生成
   const codeVerifierBytes = crypto.getRandomValues(new Uint8Array(32));
   const codeVerifier = btoa(String.fromCharCode(...codeVerifierBytes))
     .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
   const codeVerifierHash = await crypto.subtle.digest(
-    'SHA-256',
-    new TextEncoder().encode(codeVerifier)
+    'SHA-256', new TextEncoder().encode(codeVerifier)
   );
   const codeChallenge = btoa(String.fromCharCode(...new Uint8Array(codeVerifierHash)))
     .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
@@ -236,11 +177,7 @@ async function startOAuth(clientId, instanceUrl = 'https://login.salesforce.com'
       { url: authUrl, interactive: true },
       (responseUrl) => {
         if (chrome.runtime.lastError || !responseUrl) {
-          reject(
-            new Error(
-              chrome.runtime.lastError?.message || 'OAuth flow was cancelled'
-            )
-          );
+          reject(new Error(chrome.runtime.lastError?.message || 'OAuth flow was cancelled'));
           return;
         }
         resolve(responseUrl);
@@ -249,16 +186,13 @@ async function startOAuth(clientId, instanceUrl = 'https://login.salesforce.com'
   });
 
   const url = new URL(redirectUrl);
-
   const returnedState = url.searchParams.get('state');
   if (returnedState !== state) {
     throw new Error('OAuth state mismatch - possible CSRF attack');
   }
 
   const code = url.searchParams.get('code');
-  if (!code) {
-    throw new Error('Authorization code not found in redirect URL');
-  }
+  if (!code) throw new Error('Authorization code not found in redirect URL');
 
   const tokens = await exchangeCodeForTokens(
     code, instanceUrl, clientId, redirectUri, clientSecret, codeVerifier
@@ -272,23 +206,15 @@ async function startOAuth(clientId, instanceUrl = 'https://login.salesforce.com'
   );
 }
 
-/**
- * リフレッシュトークンを使って新しいアクセストークンを取得・保存する
- * @returns {Promise<string>} 新しいアクセストークン
- */
 async function refreshAccessToken() {
   const key = await getOrCreateEncryptionKey();
-
   const stored = await new Promise((resolve) => {
-    chrome.storage.local.get(
-      [
-        STORAGE_KEYS.ENCRYPTED_REFRESH_TOKEN,
-        STORAGE_KEYS.REFRESH_IV,
-        STORAGE_KEYS.INSTANCE_URL,
-        STORAGE_KEYS.CLIENT_ID,
-      ],
-      (result) => resolve(result)
-    );
+    chrome.storage.local.get([
+      STORAGE_KEYS.ENCRYPTED_REFRESH_TOKEN,
+      STORAGE_KEYS.REFRESH_IV,
+      STORAGE_KEYS.INSTANCE_URL,
+      STORAGE_KEYS.CLIENT_ID,
+    ], (result) => resolve(result));
   });
 
   if (!stored[STORAGE_KEYS.ENCRYPTED_REFRESH_TOKEN]) {
@@ -296,9 +222,7 @@ async function refreshAccessToken() {
   }
 
   const refreshToken = await decryptString(
-    key,
-    stored[STORAGE_KEYS.REFRESH_IV],
-    stored[STORAGE_KEYS.ENCRYPTED_REFRESH_TOKEN]
+    key, stored[STORAGE_KEYS.REFRESH_IV], stored[STORAGE_KEYS.ENCRYPTED_REFRESH_TOKEN]
   );
   const instanceUrl = stored[STORAGE_KEYS.INSTANCE_URL];
   const clientId = stored[STORAGE_KEYS.CLIENT_ID];
@@ -326,72 +250,44 @@ async function refreshAccessToken() {
     tokens.expires_in || 3600,
     clientId
   );
-
   return tokens.access_token;
 }
 
-/**
- * 有効なアクセストークンを返す。
- * 期限まで 5分を切っている場合はリフレッシュする。
- * @returns {Promise<string>}
- */
 async function getValidToken() {
   const key = await getOrCreateEncryptionKey();
-
   const stored = await new Promise((resolve) => {
-    chrome.storage.local.get(
-      [
-        STORAGE_KEYS.ENCRYPTED_ACCESS_TOKEN,
-        STORAGE_KEYS.TOKEN_IV,
-        STORAGE_KEYS.TOKEN_EXPIRY,
-        STORAGE_KEYS.INSTANCE_URL,
-      ],
-      (result) => resolve(result)
-    );
+    chrome.storage.local.get([
+      STORAGE_KEYS.ENCRYPTED_ACCESS_TOKEN,
+      STORAGE_KEYS.TOKEN_IV,
+      STORAGE_KEYS.TOKEN_EXPIRY,
+      STORAGE_KEYS.INSTANCE_URL,
+    ], (result) => resolve(result));
   });
 
-  if (!stored[STORAGE_KEYS.ENCRYPTED_ACCESS_TOKEN]) {
-    throw new Error('Not authenticated');
-  }
+  if (!stored[STORAGE_KEYS.ENCRYPTED_ACCESS_TOKEN]) throw new Error('Not authenticated');
 
-  const isExpiringSoon =
-    stored[STORAGE_KEYS.TOKEN_EXPIRY] - Date.now() < REFRESH_BUFFER_MS;
-
-  if (isExpiringSoon) {
-    return refreshAccessToken();
-  }
+  const isExpiringSoon = stored[STORAGE_KEYS.TOKEN_EXPIRY] - Date.now() < REFRESH_BUFFER_MS;
+  if (isExpiringSoon) return refreshAccessToken();
 
   return decryptString(
-    key,
-    stored[STORAGE_KEYS.TOKEN_IV],
-    stored[STORAGE_KEYS.ENCRYPTED_ACCESS_TOKEN]
+    key, stored[STORAGE_KEYS.TOKEN_IV], stored[STORAGE_KEYS.ENCRYPTED_ACCESS_TOKEN]
   );
 }
 
-/**
- * 接続を解除し、全トークン情報を削除する
- */
 async function disconnect() {
   return new Promise((resolve) => {
-    chrome.storage.local.remove(
-      [
-        STORAGE_KEYS.ENCRYPTED_ACCESS_TOKEN,
-        STORAGE_KEYS.ENCRYPTED_REFRESH_TOKEN,
-        STORAGE_KEYS.INSTANCE_URL,
-        STORAGE_KEYS.TOKEN_EXPIRY,
-        STORAGE_KEYS.CLIENT_ID,
-        STORAGE_KEYS.TOKEN_IV,
-        STORAGE_KEYS.REFRESH_IV,
-      ],
-      () => resolve()
-    );
+    chrome.storage.local.remove([
+      STORAGE_KEYS.ENCRYPTED_ACCESS_TOKEN,
+      STORAGE_KEYS.ENCRYPTED_REFRESH_TOKEN,
+      STORAGE_KEYS.INSTANCE_URL,
+      STORAGE_KEYS.TOKEN_EXPIRY,
+      STORAGE_KEYS.CLIENT_ID,
+      STORAGE_KEYS.TOKEN_IV,
+      STORAGE_KEYS.REFRESH_IV,
+    ], () => resolve());
   });
 }
 
-/**
- * Salesforce に接続済みかどうかを確認する
- * @returns {Promise<boolean>}
- */
 async function isConnected() {
   return new Promise((resolve) => {
     chrome.storage.local.get([STORAGE_KEYS.INSTANCE_URL], (result) => {
@@ -400,10 +296,6 @@ async function isConnected() {
   });
 }
 
-/**
- * 保存されている Salesforce インスタンス URL を返す
- * @returns {Promise<string|null>}
- */
 async function getInstanceUrl() {
   return new Promise((resolve) => {
     chrome.storage.local.get([STORAGE_KEYS.INSTANCE_URL], (result) => {
@@ -412,7 +304,6 @@ async function getInstanceUrl() {
   });
 }
 
-// Node.js (Jest) 環境向け CommonJS エクスポート
 if (typeof module !== 'undefined' && module.exports) {
   module.exports = {
     generateEncryptionKey,


### PR DESCRIPTION
## 修正\n\nトークン交換時の `client_secret` の送信方式を POST ボディから **HTTP Basic Auth ヘッダー** に変更。\n\nRFC 6749 Section 2.3.1 では confidential client の認証方式として Basic Auth が標準。Salesforce はこの形式を要求する場合がある。\n\n```\nAuthorization: Basic base64(clientId:clientSecret)\n```\n\nPKCE の `code_verifier` は引き続き POST ボディに含める。