### PR TITLE
fix(auth): background.js で clientSecret を startOAuth に渡す

### DIFF
--- a/background.js
+++ b/background.js
@@ -13,13 +13,13 @@ function handleMessage(message, sender, sendResponse) {
 
   switch (message.type) {
     case 'CONNECT_SALESFORCE': {
-      const { clientId, instanceUrl } = message;
+      const { clientId, clientSecret, instanceUrl } = message;
       // Fix 2: instanceUrl のバリデーション
       if (!validateInstanceUrl(instanceUrl)) { // eslint-disable-line no-undef
         sendResponse({ success: false, error: 'Invalid Salesforce login URL' });
         return false;
       }
-      startOAuth(clientId, instanceUrl)
+      startOAuth(clientId, instanceUrl, clientSecret)
         .then(() => sendResponse({ success: true }))
         .catch((err) => sendResponse({ success: false, error: err.message }));
       return true; // 非同期レスポンスのため


### PR DESCRIPTION
## 原因

`background.js` の `CONNECT_SALESFORCE` ハンドラーで、`message` から `clientSecret` を destructure しておらず、`startOAuth()` にも渡していなかった。

```javascript
// Before（バグあり）
const { clientId, instanceUrl } = message;  // clientSecret が抜けている
startOAuth(clientId, instanceUrl)            // clientSecret を渡していない

// After（修正後）
const { clientId, clientSecret, instanceUrl } = message;
startOAuth(clientId, instanceUrl, clientSecret)
```

## 影響

- `popup.js` から `clientSecret` を送信していても、`background.js` で受け取らないまま `startOAuth()` が `clientSecret = undefined` で呼ばれていた
- その結果、`auth.js` の `exchangeCodeForTokens()` で `clientSecret` が `falsy` となり、Basic Auth ヘッダーが付かないトークンリクエストになっていた
- Salesforce 側は client_secret 必須の設定のため `invalid_client` エラーが発生していた

## 修正内容

`background.js:16` — `clientSecret` を destructure に追加  
`background.js:22` — `startOAuth(clientId, instanceUrl, clientSecret)` に変更