### PR TITLE
fix(background): toggle-voice コマンドでアクティブタブに TOGGLE_VOICE を送信

### DIFF
--- a/background.js
+++ b/background.js
@@ -54,7 +54,11 @@ chrome.runtime.onMessage.addListener(handleMessage);
 
 chrome.commands.onCommand.addListener((command) => {
   if (command === 'toggle-voice') {
-    // TODO: Step 4 で lib/speechRecognition.js を使って実装
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      if (tabs[0]) {
+        chrome.tabs.sendMessage(tabs[0].id, { type: 'TOGGLE_VOICE' });
+      }
+    });
   }
 });
 


### PR DESCRIPTION
## 問題\n\n`background.js` の `toggle-voice` コマンドハンドラーが TODO のまま未実装だった。\nOption+V を押しても content.js に何もメッセージが届かず、音声入力 UI が起動しなかった。\n\n## 修正\n\n`chrome.commands.onCommand` ハンドラーで、アクティブタブに `TOGGLE_VOICE` メッセージを送信するよう実装。\n`content.js` 側はすでに `TOGGLE_VOICE` メッセージを受け取って `toggleVoice()` を呼ぶ実装が完成していた。