### PR TITLE
fix(manifest): content_scripts に依存 JS を追加、tabs 権限を必須化

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,11 +5,9 @@
   "description": "Salesforceを音声で操作するChrome拡張機能",
   "permissions": [
     "activeTab",
+    "tabs",
     "storage",
     "identity"
-  ],
-  "optional_permissions": [
-    "tabs"
   ],
   "host_permissions": [
     "https://*.salesforce.com/*",
@@ -26,7 +24,13 @@
         "https://*.force.com/*",
         "https://*.lightning.force.com/*"
       ],
-      "js": ["content.js"],
+      "js": [
+        "lib/ruleEngine.js",
+        "lib/navigator.js",
+        "lib/speechRecognition.js",
+        "ui/widget.js",
+        "content.js"
+      ],
       "css": ["content.css"]
     }
   ],


### PR DESCRIPTION
## 問題\n\n`content.js` が使用する `createWidget`・`createSpeechRecognition`・`match` などのグローバル関数が定義されていなかった。\n`manifest.json` の `content_scripts` に `content.js` しか含まれておらず、依存するスクリプトが読み込まれていなかった。\n\n## 修正\n\n**content_scripts の読み込み順序：**\n```\nlib/ruleEngine.js      → match() を定義\nlib/navigator.js       → buildListUrl(), navigateTo(), goBack() を定義\nlib/speechRecognition.js → createSpeechRecognition() を定義\nui/widget.js           → createWidget() を定義\ncontent.js             → 上記を使用\n```\n\n**tabs 権限：** `optional_permissions` から `permissions` に移動し、`chrome.tabs.query` が常に動作するようにした。