### PR TITLE
docs: インシデントレポート・トラブルシューティングガイド追加

### DIFF
--- a/docs/incident-report-2026-02.md
+++ b/docs/incident-report-2026-02.md
@@ -1,0 +1,283 @@
+# インシデントレポート: OAuth 認証障害・音声ナビゲーション障害
+
+**日時**: 2026-02-20 〜 2026-02-22
+**重大度**: High（音声入力機能が完全に停止）
+**状態**: 解決済み
+**担当**: iwasatat0107
+
+---
+
+## 1. 概要
+
+Playwright 自動テスト実装後から、VoiceForce Chrome 拡張機能の以下の機能が連鎖的に停止した。
+
+1. **OAuth 認証が失敗**（`invalid_client` エラー）
+2. **音声ウィジェットが表示されない**（`Option+V` が無反応）
+3. **音声コマンドで画面遷移しない**（認識はされるが遷移なし）
+
+最終的に 4 つの根本原因が特定され、PR #41・#44・#45・#46・#47 で解決した。
+
+---
+
+## 2. タイムライン
+
+| 日時 | 出来事 |
+|------|--------|
+| 2026-02-20 以前 | OAuth 接続・音声入力・画面遷移がすべて正常動作 |
+| 2026-02-20 | Playwright 自動テストを実装・マージ（Step 14 相当） |
+| 2026-02-20 〜 21 | 拡張機能の接続試行 → `invalid_client` エラーが継続発生 |
+| 2026-02-22 朝 | インシデント調査開始 |
+| 2026-02-22 | PR #41: background.js で clientSecret が渡っていないことを発見・修正 |
+| 2026-02-22 | PR #42: PKCE 不使用を試みる → `Authorization page could not be loaded` で悪化 |
+| 2026-02-22 | PR #43: PKCE のみ（secret なし）を試みる → `invalid_client` 継続 |
+| 2026-02-22 | PR #44: PKCE + clientSecret を body に含める → **OAuth 接続成功** |
+| 2026-02-22 | `npm run build` 忘れが発覚 → dist/ 同期後に認証が確認できることを検証 |
+| 2026-02-22 | PR #45: background.js の toggle-voice ハンドラーが空（TODO）だったことを発見・修正 |
+| 2026-02-22 | PR #46: manifest.json の content_scripts に依存ファイルが未記載だったことを発見・修正 |
+| 2026-02-22 | PR #47: ruleEngine.js のパターンが「してください」等に対応していないことを発見・修正 |
+| 2026-02-22 夕 | 「商談の一覧を表示してください」で画面遷移成功 → **全機能復旧** |
+
+---
+
+## 3. 根本原因分析
+
+### 根本原因 1: `background.js` — `clientSecret` が `startOAuth` に渡っていなかった
+
+**ファイル**: `background.js` の `CONNECT_SALESFORCE` ハンドラー
+
+**問題のコード**:
+```javascript
+// 修正前
+const { clientId, instanceUrl } = message;  // clientSecret が欠落
+startOAuth(clientId, instanceUrl);          // clientSecret が undefined
+```
+
+**修正後**:
+```javascript
+const { clientId, clientSecret, instanceUrl } = message;
+startOAuth(clientId, instanceUrl, clientSecret);
+```
+
+**発生原因**: 実装当初に `clientSecret` 対応が後から追加された際、destructuring だけ追加して関数呼び出しへの引数追加を漏らした。テストではモックで誤魔化されており、実機でのみ問題が顕在化していた。
+
+**PR**: #41
+
+---
+
+### 根本原因 2: `dist/` のビルド未実施
+
+**問題**: Chrome 拡張は `dist/` からロードされるが、ソース修正後に `npm run build` が実行されていなかった。そのため `dist/background.js` は古いコードのままだった。
+
+**発生原因**: 日常的な開発フローにおいて「ソース修正 → ビルド → 拡張機能再読み込み」の手順が省略されがちなため。
+
+**教訓**: ソースを修正したら **必ず** `npm run build` → 拡張機能の再読み込みを行う。これを怠ると、いくらソースを修正しても動作が変わらない。
+
+---
+
+### 根本原因 3: Salesforce External Client App は PKCE + body secret の両方が必須
+
+**ファイル**: `lib/auth.js`
+
+**背景**: Salesforce の「外部クライアントアプリケーション」は通常の Connected App とは異なる OAuth 要件を持つ。
+
+**試行錯誤の記録**:
+
+| 試した方式 | 結果 | 理由 |
+|-----------|------|------|
+| PKCE なし + secret なし | `Authorization page could not be loaded` | PKCE が必須のため認証画面が表示されない |
+| PKCE のみ（secret なし） | `invalid_client` | Secret が必須 |
+| PKCE + Basic Auth ヘッダー（`Authorization: Basic base64(key:secret)`） | `invalid_client` | Salesforce は body 渡しのみ対応 |
+| PKCE + secret を body に含める（`client_secret=...`） | **認証成功** | 正しい方式 |
+
+**正しいトークンエクスチェンジ**:
+```
+POST /services/oauth2/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=authorization_code
+&code={code}
+&client_id={consumer_key}
+&client_secret={consumer_secret}   ← body に含める（Basic Auth ではない）
+&redirect_uri={callback_url}
+&code_verifier={pkce_verifier}     ← PKCE 必須
+```
+
+**PR**: #44
+
+---
+
+### 根本原因 4: `background.js` — `toggle-voice` コマンドハンドラーが実装されていなかった
+
+**ファイル**: `background.js`
+
+**問題のコード**:
+```javascript
+chrome.commands.onCommand.addListener((command) => {
+  if (command === 'toggle-voice') {
+    // TODO: implement
+  }
+});
+```
+
+**修正後**:
+```javascript
+chrome.commands.onCommand.addListener((command) => {
+  if (command === 'toggle-voice') {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      if (tabs[0]) {
+        chrome.tabs.sendMessage(tabs[0].id, { type: 'TOGGLE_VOICE' });
+      }
+    });
+  }
+});
+```
+
+また `manifest.json` の `permissions` に `"tabs"` が `optional_permissions` 側にあったため、`chrome.tabs.query` が動作しなかった。
+
+**PR**: #45
+
+---
+
+### 根本原因 5: `manifest.json` — content_scripts に依存ファイルが未記載
+
+**ファイル**: `manifest.json`
+
+**問題**: `content.js` は `createWidget()`、`createSpeechRecognition()`、`match()`、`buildListUrl()`、`navigateTo()`、`goBack()` をグローバル関数として参照するが、これらを提供するファイルが `content_scripts` に記載されていなかった。
+
+**修正前**:
+```json
+"js": ["content.js"]
+```
+
+**修正後**:
+```json
+"js": [
+  "lib/ruleEngine.js",
+  "lib/navigator.js",
+  "lib/speechRecognition.js",
+  "ui/widget.js",
+  "content.js"
+]
+```
+
+**発生原因**: ファイル分割してモジュール化した際に、`manifest.json` への追記を忘れた。Chrome 拡張の content scripts はモジュールシステムを持たないため、依存ファイルを明示的に列挙する必要がある。
+
+**PR**: #46
+
+---
+
+### 根本原因 6: `ruleEngine.js` — 日本語パターンが不十分
+
+**ファイル**: `lib/ruleEngine.js`
+
+**問題**: 「商談の一覧を表示してください」「商談のすべてを表示してください」などの自然な日本語がマッチしなかった。
+
+**追加した対応**:
+- `SUFFIX = '(してください|ください|て)?'` — 丁寧語末尾
+- `VERB = '(出して|開いて|見せて|表示して|表示|開く|開け)'` — 動詞バリエーション
+- All / RecentlyViewed / MyOpportunities フィルターパターン
+- 「相談」→ `Opportunity` 誤認識マッピング
+
+**PR**: #47
+
+---
+
+## 4. 影響範囲
+
+| 機能 | 影響 |
+|------|------|
+| OAuth 認証 | 新規接続が不可能（既存トークンは有効だったが、セッション終了後に再認証不可） |
+| 音声ウィジェット表示 | `Option+V` が無反応 |
+| 音声コマンドでの画面遷移 | 認識はされるが遷移しない |
+| ポップアップ UI | 正常動作 |
+| バックグラウンドのトークンリフレッシュ | 影響なし |
+
+---
+
+## 5. 再発防止策
+
+### 即時対応（実施済み）
+
+| 対策 | 実施内容 | PR |
+|------|---------|----|
+| clientSecret 渡し漏れ修正 | background.js の destructuring と関数呼び出しを修正 | #41 |
+| OAuth 方式を正式仕様に固定 | PKCE + body secret の方式に統一 | #44 |
+| toggle-voice ハンドラー実装 | chrome.tabs.query でコンテンツスクリプトにメッセージを転送 | #45 |
+| manifest.json の依存関係を修正 | content_scripts に全依存ファイルを追加 | #46 |
+| ruleEngine パターン拡張 | 自然な日本語パターンに対応 | #47 |
+| トラブルシューティングガイド作成 | docs/troubleshooting.md を作成 | — |
+
+### 中長期的な対策（今後の実装時に注意）
+
+#### (1) ビルド忘れ防止
+
+開発フローに `npm run build` を組み込む。ソースを修正したら必ずビルドすること。
+
+```bash
+# 推奨フロー
+git fetch origin && git reset --hard origin/develop  # リモート同期
+npm run build                                         # ビルド
+# chrome://extensions/ → 更新                        # 拡張機能再読み込み
+```
+
+#### (2) manifest.json の content_scripts チェック
+
+新しい `lib/` または `ui/` ファイルを作成したとき、`manifest.json` の `content_scripts.js` への追記を忘れない。追加する際は `content.js` より前に記載する。
+
+#### (3) OAuth の動作確認テスト
+
+auth.js を修正した際は、必ず以下の手順で実機確認する。
+
+```
+1. 「接続を解除」で既存の接続を切断
+2. Consumer Key と Secret を入力して「Salesforceに接続」
+3. Salesforce の認証画面が表示されることを確認
+4. 許可後、「接続済み」になることを確認
+5. Option+V で音声ウィジェットが開くことを確認
+```
+
+#### (4) ruleEngine のテスト駆動開発
+
+音声パターンを追加・変更する際は、必ずテストを先に書く（TDD）。
+
+```bash
+npx jest __tests__/unit/ruleEngine.test.js --watch
+```
+
+#### (5) TODO コメントを残さない
+
+`// TODO: implement` が残っているコードは、テストでは検出されにくい。コードレビュー時に TODO が残っていないか確認する。
+
+---
+
+## 6. 学んだこと（Lessons Learned）
+
+1. **Chrome 拡張の `dist/` は常に最新を維持する**: ソース修正 = 即ビルド。これを忘れると調査に多大な時間を費やす。
+
+2. **Salesforce External Client App は PKCE + body secret が必須**: Connected App との違いを認識していなかったことで、試行錯誤に時間を要した。
+
+3. **Chrome 拡張の content scripts はロード順が重要**: ES Module ではなく、グローバルスコープへの逐次ロードであるため、依存関係の順序管理を手動で行う必要がある。
+
+4. **TODO コメントは未完成のコード**: 実装が完了するまでは動作確認ができない。ステップをマージする前に TODO が残っていないか確認する。
+
+5. **実機テストはテストコードで代替できない部分がある**: Jest テストはモック環境のため、Chrome API の連携（permissions、manifest.json の設定、コンテンツスクリプトのロード順）はカバーできない。実機での動作確認を必ずセットで行う。
+
+---
+
+## 7. 関連 PR
+
+| PR | 内容 |
+|----|------|
+| #41 | fix(background): clientSecret を startOAuth に渡すよう修正 |
+| #44 | fix(auth): PKCE + clientSecret body 方式に統一 |
+| #45 | fix(background): toggle-voice コマンドハンドラーを実装 |
+| #46 | fix(manifest): content_scripts に依存ファイルを追加 |
+| #47 | fix(rule-engine): 日本語音声パターン拡張（してください/フィルター対応） |
+
+---
+
+## 8. 参照ドキュメント
+
+- [`docs/troubleshooting.md`](./troubleshooting.md) — 症状別トラブルシューティングガイド
+- [`docs/manual-test-guide.md`](./manual-test-guide.md) — 手動テスト手順書
+- [Salesforce External Client App OAuth Documentation](https://developer.salesforce.com/docs/platform/external-client-apps/guide/eca-overview.html)

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,399 @@
+# VoiceForce トラブルシューティングガイド
+
+**最終更新**: 2026-02-22
+**対象バージョン**: v0.1.0〜
+
+このドキュメントは、VoiceForce の開発・運用中に発生しやすい問題について、症状 → 原因 → 解決手順をまとめたものです。インシデント発生時はまずこのドキュメントを参照してください。
+
+---
+
+## 目次
+
+1. [OAuth / 認証の問題](#1-oauth--認証の問題)
+2. [音声ウィジェットが表示されない](#2-音声ウィジェットが表示されない)
+3. [音声認識は動くが画面遷移しない](#3-音声認識は動くが画面遷移しない)
+4. [dist/ とソースが乖離している（最重要）](#4-dist-とソースが乖離している最重要)
+5. [音声が正確に認識されない](#5-音声が正確に認識されない)
+6. [一般的なデバッグ手順](#6-一般的なデバッグ手順)
+7. [開発後チェックリスト](#7-開発後チェックリスト)
+
+---
+
+## 1. OAuth / 認証の問題
+
+### 1-1. 症状: 「未接続」になっている / 突然切断された
+
+#### 確認手順
+
+```
+1. chrome://extensions/ → VoiceForce → 「サービスワーカー」の inspect をクリック
+2. Console タブでエラーメッセージを確認
+3. ポップアップを開き、接続ボタンを押してエラーを確認
+```
+
+#### 原因と解決
+
+| エラーメッセージ | 原因 | 解決 |
+|----------------|------|------|
+| `invalid_client` | Consumer Key/Secret が間違っているか、Salesforce 側の設定が正しくない | [→ 1-2 参照](#1-2-invalid_client-エラー) |
+| `Authorization page could not be loaded` | PKCE パラメータが抜けている | `lib/auth.js` の `startOAuth` で `code_challenge` が送られているか確認 |
+| `Token exchange failed` | `dist/` が古い（ソース修正後にビルドしていない） | `npm run build` 実行後、拡張機能を再読み込み |
+| `unauthorized sender` | 別の拡張機能からメッセージが送信された | 正常な保護動作。ユーザー操作からのメッセージは正しくルーティングされているか確認 |
+
+---
+
+### 1-2. `invalid_client` エラー
+
+VoiceForce は **Salesforce External Client App（外部クライアントアプリケーション）** を使用しているため、認証には以下の **3条件がすべて必要** です。
+
+```
+✅ PKCE (code_challenge + code_challenge_method: 'S256')
+✅ Consumer Secret を POST body に含める (client_secret=...)
+✅ grant_type=authorization_code
+```
+
+#### 正しいトークンエクスチェンジのリクエスト形式
+
+```
+POST https://{instance}.salesforce.com/services/oauth2/token
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=authorization_code
+&code={authorization_code}
+&client_id={consumer_key}
+&client_secret={consumer_secret}       ← 必須（Basic Auth ヘッダーではなく body に）
+&redirect_uri={callback_url}
+&code_verifier={pkce_verifier}         ← 必須
+```
+
+#### よくある間違い
+
+| 間違い | 正しい対応 |
+|--------|----------|
+| `Authorization: Basic base64(key:secret)` ヘッダーで送信 | body の `client_secret` パラメータで送信 |
+| `code_verifier` を送らない | `startOAuth` で生成した verifier を `exchangeCodeForTokens` に渡す |
+| `code_challenge_method: 'plain'` を使用 | `'S256'` を使用（SHA-256 ハッシュ） |
+
+#### Salesforce 外部クライアントアプリ設定確認項目
+
+```
+Salesforce Setup → App Manager → VoiceForce → 編集
+├── OAuth フロー: 有効化済みか
+├── コールバック URL: https://{拡張機能ID}.chromiumapp.org/oauth
+│   ※ 拡張機能 ID は chrome://extensions/ で確認
+├── OAuth スコープ: 「API を利用してユーザーデータを管理」が含まれているか
+└── アプリを有効化: オンになっているか
+```
+
+---
+
+### 1-3. コールバック URL の確認
+
+拡張機能 ID は Chrome のアップデートやプロファイル変更で変わることがあります。
+
+```
+コールバック URL = https://{拡張機能ID}.chromiumapp.org/oauth
+
+拡張機能IDの確認:
+chrome://extensions/ → VoiceForce → 「ID」フィールド
+```
+
+Salesforce 側の登録 URL と一致しているか確認してください。
+
+---
+
+## 2. 音声ウィジェットが表示されない
+
+### 2-1. 症状: `Option+V` を押してもウィジェットが表示されない
+
+#### 診断フロー
+
+```
+Option+V を押す
+    │
+    ├─ ショートカットキーが反応していない？
+    │       → chrome://extensions/shortcuts でキーが設定されているか確認
+    │
+    ├─ background.js にメッセージが届いていない？
+    │       → サービスワーカーの Console で TOGGLE_VOICE ログを確認
+    │
+    ├─ content.js が Salesforce ページで実行されていない？
+    │       → DevTools → Console で「content.js is running」を確認
+    │       → Salesforce URL が host_permissions に含まれているか確認
+    │
+    └─ createWidget() / createSpeechRecognition() / match() が undefined？
+            → manifest.json の content_scripts のロード順を確認（→ 2-2 参照）
+```
+
+---
+
+### 2-2. manifest.json の content_scripts ロード順
+
+content.js は以下の関数をグローバル変数として参照します。これらは **content.js より前にロードされている必要** があります。
+
+```json
+"content_scripts": [{
+  "matches": ["https://*.salesforce.com/*", ...],
+  "js": [
+    "lib/ruleEngine.js",       // match() を提供
+    "lib/navigator.js",        // buildListUrl(), navigateTo(), goBack() を提供
+    "lib/speechRecognition.js", // createSpeechRecognition() を提供
+    "ui/widget.js",            // createWidget() を提供
+    "content.js"               // ← 最後に読み込む
+  ]
+}]
+```
+
+**よくある間違い**: `content.js` だけを指定して依存ファイルを省略してしまう。
+
+---
+
+### 2-3. background.js の toggle-voice コマンドハンドラー
+
+`chrome.commands.onCommand` リスナーは **必ず** コンテンツスクリプトへのメッセージ転送を実装していること。
+
+```javascript
+chrome.commands.onCommand.addListener((command) => {
+  if (command === 'toggle-voice') {
+    chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
+      if (tabs[0]) {
+        chrome.tabs.sendMessage(tabs[0].id, { type: 'TOGGLE_VOICE' });
+      }
+    });
+  }
+});
+```
+
+また、`manifest.json` の `permissions` に **`"tabs"` が含まれていること** を確認してください（`optional_permissions` ではなく `permissions`）。
+
+---
+
+## 3. 音声認識は動くが画面遷移しない
+
+### 3-1. 症状: ウィジェットに発話が表示されるが、画面遷移が起きない
+
+#### 診断フロー
+
+```
+発話がウィジェットに表示される
+    │
+    ├─ ruleEngine.match() が null を返している
+    │       → DevTools Console で match('商談の一覧を表示してください') を実行
+    │       → null なら → 3-2 パターンマッチング確認
+    │
+    ├─ match() が intent を返しているが navigate でない
+    │       → intent.action の値を確認
+    │
+    ├─ filterName 付き navigate で Salesforce API エラー
+    │       → Console の fetch エラーを確認
+    │       → フォールバック（filterName なし URL）で遷移しているか確認
+    │
+    └─ buildListUrl() / navigateTo() が undefined
+            → manifest.json の content_scripts に lib/navigator.js が含まれているか確認
+```
+
+---
+
+### 3-2. ruleEngine.js パターンマッチング
+
+`lib/ruleEngine.js` の QUICK_PATTERNS は以下の日本語パターンに対応しています。
+
+#### 対応パターン一覧
+
+| 発話例 | マッチするパターン | 結果 |
+|--------|-----------------|------|
+| 「商談」「商談の一覧」「商談リスト」 | オブジェクト一覧（フィルターなし） | navigate Opportunity list |
+| 「商談を開いて」「商談出して」「商談を表示してください」 | 動詞付きオブジェクト | navigate Opportunity list |
+| 「商談一覧を開いて」「商談の一覧を表示してください」 | 一覧指定 + 動詞 | navigate Opportunity list |
+| 「すべての商談を開いて」「全ての商談」「商談の全てを表示して」 | All フィルター | navigate filterName: All |
+| 「最近の商談を開いて」「最近参照した商談を表示して」 | RecentlyViewed フィルター | navigate filterName: RecentlyViewed |
+| 「自分の商談を開いて」「商談の自分の分を表示して」 | MyOpportunities フィルター | navigate filterName: MyOpportunities |
+| 「相談」 | Opportunity 誤認識マッピング | navigate Opportunity list |
+
+#### 新しいパターンを追加する際の手順
+
+```javascript
+// 1. QUICK_PATTERNS に新しいオブジェクトを追加
+{
+  patterns: [
+    /^新しいパターン$/,
+  ],
+  resolve: (m) => ({
+    action: 'navigate',
+    object: '...',
+    target: 'list',
+    confidence: 1.0,
+    message: '...',
+  }),
+},
+
+// 2. テストを追加
+// __tests__/unit/ruleEngine.test.js に対応テストケースを追加
+
+// 3. テスト実行
+// npx jest __tests__/unit/ruleEngine.test.js
+
+// 4. ビルド
+// npm run build
+```
+
+---
+
+## 4. `dist/` とソースが乖離している（最重要）
+
+### 問題の背景
+
+Chrome 拡張機能は **`dist/` ディレクトリ** からロードされています。ソースファイル（`lib/`, `ui/`, `background.js` など）を修正しても、`npm run build` を実行しなければ Chrome には反映されません。
+
+### 症状
+
+- ソースを修正したのに動作が変わらない
+- コンソールで古いエラーが出続ける
+- テストはパスするのに実機で動かない
+
+### 解決手順（修正作業後は必ず実施）
+
+```bash
+# 1. ソース変更をビルド
+npm run build
+
+# 2. Chrome で拡張機能を再読み込み
+# chrome://extensions/ → VoiceForce → 更新ボタン（↻）をクリック
+
+# 3. Salesforce ページをリロード（Content Script を再実行させる）
+# Salesforce のページで Cmd+R
+```
+
+### リモートとの同期が必要な場合（GitHub MCP マージ後）
+
+```bash
+git fetch origin && git reset --hard origin/develop
+npm run build
+# → Chrome 拡張を再読み込み
+```
+
+### 重要な `dist/` のルール
+
+- `dist/` は `.gitignore` に **含まれない**（CI でビルドして Chrome Web Store に提出するため）
+- ソースを直接 `dist/` に編集してはいけない（次の `npm run build` で上書きされる）
+- PR マージ後に必ず手元で `npm run build` を実行する
+
+---
+
+## 5. 音声が正確に認識されない
+
+### 5-1. Web Speech API の特性
+
+VoiceForce は `webkitSpeechRecognition`（Web Speech API）を使用しており、以下の特性があります。
+
+| 特性 | 詳細 |
+|------|------|
+| 言語設定 | `lang: 'ja-JP'` で日本語認識 |
+| 認識モード | `interimResults: false`（最終結果のみ） |
+| マイク | `continuous: false`（1発話で停止） |
+| ノイズ | 静かな環境での認識精度が高い |
+
+### 5-2. 誤認識されやすいパターンと対策
+
+| 音声入力 | 誤認識例 | 対策 |
+|---------|---------|------|
+| 「商談」 | 「相談」 | ruleEngine で `'相談'` → `Opportunity` マッピング済み |
+| 数字「いち」 | 「一」「1」 | ruleEngine で漢数字・算用数字両対応済み |
+| 「OK」 | 「オッケー」「オーケー」 | confirm パターンで複数形式対応済み |
+
+### 5-3. 認識率が低い場合のチェックリスト
+
+```
+□ マイクのアクセス許可が「許可」になっているか
+  → chrome://settings/content/microphone
+
+□ マイクデバイスが正しく選択されているか
+  → Chrome の設定 → プライバシーとセキュリティ → サイトの設定 → マイク
+
+□ 静かな環境で話しているか
+
+□ はっきり・ゆっくり話しているか
+
+□ 発話後に少し待っているか（認識完了のタイムラグがある）
+```
+
+### 5-4. 新しい音声パターンへの対応手順
+
+1. `lib/ruleEngine.js` の `QUICK_PATTERNS` に追加
+2. `__tests__/unit/ruleEngine.test.js` にテストケースを追加
+3. `npm test` でテスト通過を確認
+4. `npm run build` 後に実機確認
+
+---
+
+## 6. 一般的なデバッグ手順
+
+### 6-1. コンソールログの場所
+
+| コンポーネント | ログの確認場所 |
+|-------------|-------------|
+| Service Worker (background.js) | `chrome://extensions/` → VoiceForce → 「サービスワーカー」リンク → inspect |
+| Content Script (content.js, lib/, ui/) | Salesforce ページの DevTools → Console |
+| Popup (popup.js) | ポップアップを右クリック → 検証 → Console |
+
+### 6-2. よく使うデバッグコマンド
+
+Salesforce ページの DevTools Console で実行：
+
+```javascript
+// ruleEngine のパターンマッチングを直接確認
+match('商談の一覧を表示してください')
+// → { action: 'navigate', object: 'Opportunity', target: 'list', ... }
+
+// navigator の URL 生成を確認
+buildListUrl('https://example.my.salesforce.com', 'Opportunity')
+// → 'https://example.my.salesforce.com/lightning/o/Opportunity/list'
+
+// 現在ページの URL 解析
+parseUrl(window.location.href)
+// → { type: 'list', objectName: 'Opportunity', recordId: null }
+```
+
+### 6-3. chrome.storage の確認
+
+```javascript
+// Service Worker の inspect → Console で実行
+chrome.storage.local.get(null, console.log)
+// → { instance_url: '...', access_token_enc: '...', enc_iv: '...' }
+
+// セッションストレージ（暗号化キー）
+chrome.storage.session.get(null, console.log)
+```
+
+---
+
+## 7. 開発後チェックリスト
+
+ソースを修正して GitHub MCP でマージした後、必ず以下を実施してください。
+
+```
+□ npm run build を実行した
+□ chrome://extensions/ → VoiceForce → 更新ボタンをクリックした
+□ Salesforce ページをリロードした
+□ ウィジェットが Option+V で開くことを確認した
+□ 「商談の一覧を表示してください」で画面遷移することを確認した
+□ ポップアップで「接続済み」になっていることを確認した
+```
+
+### 修正内容別の追加確認
+
+| 修正内容 | 追加確認 |
+|---------|----------|
+| `lib/auth.js` | 一度「接続を解除」してから再接続を試す |
+| `manifest.json` | Chrome 拡張をアンロード → 再ロードする（更新ボタンだけでは不十分な場合あり） |
+| `lib/ruleEngine.js` | `npx jest __tests__/unit/ruleEngine.test.js` でテストが通ることを確認 |
+| `background.js` | サービスワーカーを inspect → 再起動 |
+| `ui/widget.js` | ウィジェットの 6 状態（idle/listening/processing/confirm/success/error）を目視確認 |
+
+---
+
+## 関連ドキュメント
+
+- [`docs/incident-report-2026-02.md`](./incident-report-2026-02.md) — 2026年2月 OAuth・音声ナビゲーション障害 ポストモーテム
+- [`docs/manual-test-guide.md`](./manual-test-guide.md) — 手動テスト手順書
+- [`DESIGN_DOC.md`](../DESIGN_DOC.md) — 設計仕様書


### PR DESCRIPTION
## Summary
- `docs/troubleshooting.md` — 症状別トラブルシューティングガイドを新規作成
  - OAuth/認証問題、ウィジェット表示問題、画面遷移問題、dist/ビルド忘れ、音声認識問題を網羅
  - 各問題の診断フロー・解決手順・開発後チェックリストを記載
- `docs/incident-report-2026-02.md` — 2026年2月に発生した連鎖障害のポストモーテムを新規作成
  - 6つの根本原因を分析・記録
  - Salesforce External Client App の正しい OAuth 方式（PKCE + body secret）を明文化
  - 再発防止策と Lessons Learned を記載

## 対象インシデント
- Playwright テスト実装後から OAuth 認証が `invalid_client` で失敗
- `Option+V` で音声ウィジェットが表示されない
- 音声コマンドで画面遷移しない（PR #41, #44, #45, #46, #47 で解決済み）

## Test plan
- [ ] ドキュメントの Markdown レンダリングが正しいこと
- [ ] リンク（`troubleshooting.md` ↔ `incident-report-2026-02.md`）が正しいこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)