### PR TITLE
fix(test): Playwright テストを Jest から除外・background.test の引数不一致修正

### DIFF
--- a/__tests__/unit/background.test.js
+++ b/__tests__/unit/background.test.js
@@ -118,7 +118,8 @@ describe('background.js', () => {
       expect(result).toBe(true);
       expect(global.startOAuth).toHaveBeenCalledWith(
         'test_client',
-        'https://login.salesforce.com'
+        'https://login.salesforce.com',
+        undefined
       );
     });
   });

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,8 @@ module.exports = {
   testMatch: ['**/*.test.js'],
   testPathIgnorePatterns: [
     '/node_modules/',
-    '__tests__/prompt/' // プロンプトテストはCIでは除外・手動実行のみ
+    '__tests__/prompt/',    // プロンプトテストはCIでは除外・手動実行のみ
+    '__tests__/playwright/' // Playwrightテストは npx playwright test で実行
   ],
   collectCoverageFrom: [
     'lib/**/*.js',


### PR DESCRIPTION
## Summary
- `jest.config.js` に `__tests__/playwright/` を `testPathIgnorePatterns` に追加（Playwright テストは `npx playwright test` で実行するため Jest から除外）
- `background.test.js` の `startOAuth` 呼び出し引数を修正（3引数目 `clientSecret` が `undefined` になるケースに対応）

## Result
- Jest: 582 tests, 20 suites, all passing ✅
- Coverage: branches 70%+ / functions・lines・statements 80%+ ✅