### PR TITLE
fix: Playwright 全55テストをグリーンに（ruleEngine/navigator/popup修正）

### DIFF
--- a/__tests__/playwright/popup.test.js
+++ b/__tests__/playwright/popup.test.js
@@ -75,8 +75,9 @@ test('コンシューマーキー未入力で接続ボタンを押すとエラ�
 
   await page.locator('#connect-btn').click();
 
+  // CSS transition を回避するためインラインスタイルを直接確認
   const borderColor = await page.locator('#client-id-input').evaluate(
-    el => window.getComputedStyle(el).borderColor
+    el => el.style.borderColor
   );
   expect(borderColor).toContain('239'); // rgb(239, 68, 68) = #ef4444
 

--- a/lib/navigator.js
+++ b/lib/navigator.js
@@ -60,8 +60,9 @@ function parseUrl(url) {
  * @param {string} objectName
  * @returns {string}
  */
-function buildListUrl(instanceUrl, objectName) {
-  return `${instanceUrl}/lightning/o/${objectName}/list`;
+function buildListUrl(instanceUrl, objectName, filterId) {
+  const base = `${instanceUrl}/lightning/o/${objectName}/list`;
+  return filterId ? `${base}?filterName=${filterId}` : base;
 }
 
 /**

--- a/lib/ruleEngine.js
+++ b/lib/ruleEngine.js
@@ -78,8 +78,8 @@ const QUICK_PATTERNS = [
   // ── 自分のフィルター付き一覧 ────────────────────────────────────────
   {
     patterns: [
-      new RegExp(`^(自分|私|自分の|私の)(${OBJECT_NAMES})(を)?${VERB}?${SUFFIX}$`),
-      new RegExp(`^(${OBJECT_NAMES})(の)?(自分|私)(の)?(分)?(を)?${VERB}?${SUFFIX}$`),
+      new RegExp(`^(自分|私|自分の|私の)(${OBJECT_NAMES})(一覧|リスト)?(を)?${VERB}?${SUFFIX}$`),
+      new RegExp(`^(${OBJECT_NAMES})(の)?(自分|私)(の)?(分)?(一覧|リスト)?(を)?${VERB}?${SUFFIX}$`),
     ],
     resolve: (m) => {
       const obj = LABEL_TO_API_EXTENDED[m[2]] || LABEL_TO_API_EXTENDED[m[1]] || LABEL_TO_API[m[2]] || LABEL_TO_API[m[1]];


### PR DESCRIPTION
## Summary
- `ruleEngine.js`: `私の商談一覧` など「一覧/リスト」を末尾に持つパターンをマッチするよう `(一覧|リスト)?` を追加
- `navigator.js`: `buildListUrl(instanceUrl, objectName, filterId)` に第3引数 `filterId` を追加し、`?filterName=xxx` の URL 生成に対応
- `__tests__/playwright/popup.test.js`: CSS `transition: border-color 0.15s` の影響で `getComputedStyle` が遷移前の値を返す問題を `el.style.borderColor`（インラインスタイル直接参照）で修正

## Result
- Playwright: 55/55 passed ✅
- Jest: 582/582 passed ✅