### PR TITLE
chore: バージョン 1.0.0 に更新（Chrome Web Store 申請準備）

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Salesforce Voice Assistant",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Salesforceを音声で操作するChrome拡張機能",
   "permissions": [
     "activeTab",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "voiceforce",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "Salesforceを音声で操作するChrome拡張機能",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## Summary

- `manifest.json` バージョンを `0.1.0` → `1.0.0` に更新
- `package.json` バージョンを `0.1.0` → `1.0.0` に更新

## Test Results

- Jest: 582/582 passing ✅
- カバレッジ: branches 83%, functions 97%, lines 97% ✅
- ビルド: `npm run build` 成功 ✅
- パッケージ: `dist/voiceforce-v1.0.0.zip` 生成成功 ✅

## 次のステップ

このPRマージ後:
1. `release/v1.0.0` ブランチを作成して `develop → main` へのリリースPRを作成
2. Chrome Web Store デベロッパーダッシュボードに ZIP をアップロード

🤖 Generated with [Claude Code](https://claude.com/claude-code)