### PR TITLE
feat(rule-engine): 「〇〇を表示して」パターン拡張（オブジェクト先行形式・キャッチオール）

### DIFF
--- a/__tests__/unit/ruleEngine.test.js
+++ b/__tests__/unit/ruleEngine.test.js
@@ -388,6 +388,35 @@ describe('RuleEngine', () => {
     });
   });
 
+  describe('search patterns - オブジェクト先行形式（逆順）', () => {
+    test.each([
+      ['取引先のABC株式会社を表示して', 'Account',     'ABC株式会社'],
+      ['商談の田中商事を開いて',        'Opportunity', '田中商事'],
+      ['取引先責任者の山田太郎を見せて', 'Contact',    '山田太郎'],
+      ['リードのテスト株式会社を表示して', 'Lead',     'テスト株式会社'],
+    ])('「%s」→ search/%s/keyword=%s', (input, object, keyword) => {
+      const result = ruleEngine.match(input);
+      expect(result).toEqual(expect.objectContaining({ action: 'search', object, keyword }));
+    });
+  });
+
+  describe('search patterns - オブジェクト指定なし（キャッチオール）', () => {
+    test.each([
+      ['ABC株式会社を表示して', 'Account', 'ABC株式会社'],
+      ['田中商事を見せて',      'Account', '田中商事'],
+      ['テスト商事を開いて',    'Account', 'テスト商事'],
+    ])('「%s」→ search/Account/keyword=%s', (input, object, keyword) => {
+      const result = ruleEngine.match(input);
+      expect(result).toEqual(expect.objectContaining({ action: 'search', object, keyword }));
+    });
+
+    test('オブジェクト名単独はキャッチオールにマッチしない（navigate が先）', () => {
+      // 「商談を開いて」は navigate であるべき
+      const result = ruleEngine.match('商談を開いて');
+      expect(result?.action).toBe('navigate');
+    });
+  });
+
   // ─── 入力長制限（Fix 11） ──────────────────────────────────────────────
   describe('入力長制限', () => {
     test('500文字 → 正常処理（マッチしない文字列だが null を返す）', () => {

--- a/lib/ruleEngine.js
+++ b/lib/ruleEngine.js
@@ -144,6 +144,35 @@ const QUICK_PATTERNS = [
     },
   },
 
+  // ── レコード検索（オブジェクト先行形式）──────────────────────────────
+  {
+    patterns: [
+      // 例: 「取引先のABC株式会社を表示して」「商談の田中商事を開いて」
+      new RegExp(`^(${OBJECT_NAMES})の(.+?)を${VERB}?${SUFFIX}$`),
+    ],
+    resolve: (m) => ({
+      action: 'search',
+      object: LABEL_TO_API_EXTENDED[m[1]] || LABEL_TO_API[m[1]],
+      keyword: m[2],
+      confidence: 1.0,
+    }),
+  },
+
+  // ── レコード検索（オブジェクト指定なし）──────────────────────────────
+  {
+    patterns: [
+      // 例: 「ABC株式会社を表示して」「田中商事を見せて」
+      // ナビゲートパターンより後ろに配置するため、「商談を開いて」等は到達しない
+      new RegExp(`^(.+?)を${VERB}${SUFFIX}$`),
+    ],
+    resolve: (m) => ({
+      action: 'search',
+      object: 'Account',
+      keyword: m[1],
+      confidence: 0.8,
+    }),
+  },
+
   // ── 確認応答（はい） ─────────────────────────────────────────────────
   {
     patterns: [/^(はい|うん|OK|オッケー|いいよ|お願い|実行して|そう|ええ)$/i],


### PR DESCRIPTION
## Summary

- `lib/ruleEngine.js` に検索パターンを2つ追加
  - **Pattern 5a（オブジェクト先行形式）**: 「取引先のABC株式会社を表示して」→ `search/Account/keyword=ABC株式会社`
  - **Pattern 5b（キャッチオール）**: 「ABC株式会社を表示して」→ `search/Account/keyword=ABC株式会社`
- `__tests__/unit/ruleEngine.test.js` に対応テストケース8件追加（計622件 → PASS）

## 根本原因

1. 語順が逆のパターン（object + の + keyword）が存在しなかった
2. オブジェクト指定なしパターンが存在せず、`match()` が null を返していた

## 既存パターンへの影響なし

- `商談を開いて` → navigate（Pattern 4 が先にキャッチ）
- `最近の商談を開いて` → navigate/Recent（変更なし）
- `自分の商談を開いて` → navigate/MyOpportunities（変更なし）

## Test plan

- [x] `npx jest __tests__/unit/ruleEngine.test.js` → 125件 PASS
- [x] `npm test` → 622件 全 PASS
- [ ] `npm run build` → dist/ に反映
- [ ] Chrome拡張リロード → 実機テスト（「取引先のABC株式会社を表示して」「ABC株式会社を表示して」）

🤖 Generated with [Claude Code](https://claude.com/claude-code)