### PR TITLE
ci: pre-push フック + CI/CD 絶対原則をドキュメント化（再発防止）

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,29 @@
+#!/bin/sh
+#
+# pre-push フック: プッシュ前に lint + test を自動実行
+#
+# CI で失敗する変更をリモートに送らないための安全装置。
+# このフックを通過しない限りプッシュは実行されない。
+#
+# インストール: npm run prepare（または git config core.hooksPath .githooks）
+# スキップ（緊急時のみ）: git push --no-verify
+#   ※ --no-verify を使う場合は必ず CI PASS を確認してからマージすること
+
+set -e
+
+echo ""
+echo "=== pre-push: CI チェック開始 ==="
+echo ""
+
+echo "--- 1/2  Lint ---"
+npm run lint
+echo "    Lint: OK"
+echo ""
+
+echo "--- 2/2  Test ---"
+npm test --silent
+echo "    Test: OK"
+echo ""
+
+echo "=== pre-push: 全チェック通過。プッシュを続行します。 ==="
+echo ""

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "build": "node scripts/build.js",
-    "package": "node scripts/package.js"
+    "package": "node scripts/package.js",
+    "prepare": "git config core.hooksPath .githooks"
   },
   "devDependencies": {
     "eslint": "^8.57.0",


### PR DESCRIPTION
## Summary

Lint エラー13件が長期間放置されて CI が壊れ続けた反省から、同じことが起こらないよう仕組み化・ドキュメント化。

### 変更内容

**`.githooks/pre-push`（新規）**
プッシュ前に `npm run lint` + `npm test` を自動実行するフック。エラーがあればプッシュ自体をブロックする。
```
git push → lint → test → OK → プッシュ実行
                       ↓ NG → プッシュ中断
```

**`package.json`**
`"prepare"` スクリプトを追加。`npm install` 後に自動で `git config core.hooksPath .githooks` が実行され、フックがインストールされる。

**`CLAUDE.md`**
「CI/CD 絶対原則」セクションを追加（6ルール）:
- R1: CI が赤の状態では新しい作業を始めない
- R2: PR は CI 全ジョブ PASS を確認してからマージ
- R3: セッション開始時に develop の CI 状態を確認
- R4: Lint エラーはその PR で即修正・持ち越し禁止
- R5: テストを「パスするように」書き換えることは禁止
- R6: `--no-verify` は緊急時のみ

## Test plan

- [x] `npm run lint` → エラー 0件
- [x] `npm test` → 622件 全 PASS
- [x] `git push` 実行時に pre-push フックが動作し lint + test を実行することを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)