### PR TITLE
fix(search): URL遷移 → グローバル検索バーへの DOM 入力 + Enter に変更

### DIFF
--- a/content.js
+++ b/content.js
@@ -58,12 +58,38 @@ if (isSalesforceUrl) {
           w.setState('success', { message: '前のページに戻ります' });
 
         } else if (intent && intent.action === 'search') {
-          chrome.storage.local.get(['instance_url'], (result) => {
-            const instanceUrl = result.instance_url || window.location.origin;
-            const url = buildSearchUrl(instanceUrl, intent.keyword); // eslint-disable-line no-undef
-            w.setState('success', { message: `「${intent.keyword}」を検索します` });
-            setTimeout(() => navigateTo(url), 1000); // eslint-disable-line no-undef
-          });
+          const keyword = intent.keyword;
+          w.setState('success', { message: `「${keyword}」を検索します` });
+          setTimeout(() => {
+            // Salesforce グローバル検索バーにキーワードを入力して Enter を送信
+            const SEARCH_SELECTORS = [
+              '.slds-global-header__search input',
+              'input[type="search"]',
+              'input[aria-label*="Search"]',
+              'input[aria-label*="検索"]',
+            ];
+            let input = null;
+            for (const sel of SEARCH_SELECTORS) {
+              input = document.querySelector(sel);
+              if (input) break;
+            }
+            if (input) {
+              input.focus();
+              const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
+              setter.call(input, keyword);
+              input.dispatchEvent(new Event('input', { bubbles: true }));
+              input.dispatchEvent(new KeyboardEvent('keydown',  { key: 'Enter', keyCode: 13, bubbles: true }));
+              input.dispatchEvent(new KeyboardEvent('keypress', { key: 'Enter', keyCode: 13, charCode: 13, bubbles: true }));
+              input.dispatchEvent(new KeyboardEvent('keyup',    { key: 'Enter', keyCode: 13, bubbles: true }));
+            } else {
+              // 検索バーが見つからない場合は URL フォールバック
+              chrome.storage.local.get(['instance_url'], (storageResult) => {
+                const instanceUrl = storageResult.instance_url || window.location.origin;
+                const url = buildSearchUrl(instanceUrl, keyword); // eslint-disable-line no-undef
+                navigateTo(url); // eslint-disable-line no-undef
+              });
+            }
+          }, 500);
 
         } else {
           w.setState('success', { message: `認識: ${transcript}` });


### PR DESCRIPTION
## Summary

- Salesforce Lightning SPA で `window.location.href = /lightning/search?searchInput=...` が内部ルーターと競合してスピナーのままになる問題を修正
- グローバル検索バーの `<input>` を直接操作し、キーワードをセットして Enter を送信する方式に変更
- Salesforce が検索処理を担う（VoiceForce は UI 操作のみ）

## 実装詳細

```
発話 → ruleEngine → content.js
  → .slds-global-header__search input を querySelector
  → nativeInputSetter で値セット（LWC リアクティブ対応）
  → keydown / keypress / keyup (Enter) dispatch
  → Salesforce が検索実行・結果表示
```

フォールバック: 検索バー要素が見つからない場合は従来の `/lightning/search?searchInput=...` URL ナビゲーション

## Test plan

- [x] `npm run lint` — エラー 0件
- [x] `npm test` — 622件全 PASS
- [x] `npm run build` — dist/ ビルド成功
- [ ] 実機テスト: `Option+V` → 「ABC株式会社を表示して」→ 検索バーに「ABC株式会社」が入力され検索結果が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)