### PR TITLE
fix(search): Shadow DOM・SPA競合を回避し chrome.tabs.update で検索遷移を実装

### DIFF
--- a/__tests__/unit/background.test.js
+++ b/__tests__/unit/background.test.js
@@ -125,6 +125,41 @@ describe('background.js', () => {
   });
 
   // ──────────────────────────────────────────
+  // NAVIGATE_TO_SEARCH
+  // ──────────────────────────────────────────
+  describe('handleMessage — NAVIGATE_TO_SEARCH', () => {
+    test('有効な keyword → chrome.tabs.update が正しい Salesforce 検索 URL で呼ばれる', () => {
+      const sender = {
+        id: chrome.runtime.id,
+        tab: { id: 42, url: 'https://myorg.my.salesforce.com/lightning/o/Opportunity/list' },
+      };
+      const message = { type: 'NAVIGATE_TO_SEARCH', keyword: 'ABC株式会社' };
+      const sendResponse = jest.fn();
+
+      const result = background.handleMessage(message, sender, sendResponse);
+      expect(result).toBe(false);
+      expect(chrome.tabs.update).toHaveBeenCalledWith(
+        42,
+        { url: 'https://myorg.my.salesforce.com/lightning/search?searchInput=ABC%E6%A0%AA%E5%BC%8F%E4%BC%9A%E7%A4%BE' }
+      );
+    });
+
+    test('keyword が空文字 → エラーレスポンスを返す', () => {
+      const sender = {
+        id: chrome.runtime.id,
+        tab: { id: 42, url: 'https://myorg.my.salesforce.com/lightning/page/home' },
+      };
+      const message = { type: 'NAVIGATE_TO_SEARCH', keyword: '' };
+      const sendResponse = jest.fn();
+
+      const result = background.handleMessage(message, sender, sendResponse);
+      expect(result).toBe(false);
+      expect(sendResponse).toHaveBeenCalledWith({ success: false, error: 'invalid keyword' });
+      expect(chrome.tabs.update).not.toHaveBeenCalled();
+    });
+  });
+
+  // ──────────────────────────────────────────
   // 未知のメッセージタイプ
   // ──────────────────────────────────────────
   describe('handleMessage — unknown message type', () => {

--- a/background.js
+++ b/background.js
@@ -44,6 +44,18 @@ function handleMessage(message, sender, sendResponse) {
         .catch((err) => sendResponse({ success: false, error: err.message }));
       return true;
 
+    case 'NAVIGATE_TO_SEARCH': {
+      const { keyword } = message;
+      if (!keyword || typeof keyword !== 'string') {
+        sendResponse({ success: false, error: 'invalid keyword' });
+        return false;
+      }
+      const tabOrigin = new URL(sender.tab.url).origin;
+      const searchUrl = `${tabOrigin}/lightning/search?searchInput=${encodeURIComponent(keyword)}`;
+      chrome.tabs.update(sender.tab.id, { url: searchUrl });
+      return false;
+    }
+
     default:
       sendResponse({ success: false, error: 'unknown message type' });
       return false;

--- a/content.js
+++ b/content.js
@@ -61,35 +61,8 @@ if (isSalesforceUrl) {
           const keyword = intent.keyword;
           w.setState('success', { message: `「${keyword}」を検索します` });
           setTimeout(() => {
-            // Salesforce グローバル検索バーにキーワードを入力して Enter を送信
-            const SEARCH_SELECTORS = [
-              '.slds-global-header__search input',
-              'input[type="search"]',
-              'input[aria-label*="Search"]',
-              'input[aria-label*="検索"]',
-            ];
-            let input = null;
-            for (const sel of SEARCH_SELECTORS) {
-              input = document.querySelector(sel);
-              if (input) break;
-            }
-            if (input) {
-              input.focus();
-              const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value').set;
-              setter.call(input, keyword);
-              input.dispatchEvent(new Event('input', { bubbles: true }));
-              input.dispatchEvent(new KeyboardEvent('keydown',  { key: 'Enter', keyCode: 13, bubbles: true }));
-              input.dispatchEvent(new KeyboardEvent('keypress', { key: 'Enter', keyCode: 13, charCode: 13, bubbles: true }));
-              input.dispatchEvent(new KeyboardEvent('keyup',    { key: 'Enter', keyCode: 13, bubbles: true }));
-            } else {
-              // 検索バーが見つからない場合は URL フォールバック
-              chrome.storage.local.get(['instance_url'], (storageResult) => {
-                const instanceUrl = storageResult.instance_url || window.location.origin;
-                const url = buildSearchUrl(instanceUrl, keyword); // eslint-disable-line no-undef
-                navigateTo(url); // eslint-disable-line no-undef
-              });
-            }
-          }, 500);
+            chrome.runtime.sendMessage({ type: 'NAVIGATE_TO_SEARCH', keyword });
+          }, 800);
 
         } else {
           w.setState('success', { message: `認識: ${transcript}` });


### PR DESCRIPTION
## 問題

「ABC株式会社を表示して」と発話してもウィジェットに「「ABC株式会社」を検索します」と表示されるだけで検索が実行されなかった。

**二重の障壁:**
1. **Shadow DOM**: Salesforce Lightning は LWC で実装されており `document.querySelector('.slds-global-header__search input')` が常に `null` を返す
2. **SPA ルーター競合**: `window.location.href` による `/lightning/search` 遷移が Aura/LWC ルーターと競合してスピナーになる

## 解決策

`chrome.tabs.update(tabId, { url })` を使ったブラウザレベルのナビゲーションに転換。
ユーザーがアドレスバーに URL を入力したのと同等の遷移を発生させ、Shadow DOM 問題も SPA 競合も発生しない。

```
発話 → ruleEngine → content.js
  → sendMessage({ type: 'NAVIGATE_TO_SEARCH', keyword })
  → background.js: sender.tab.url から origin を取得
  → chrome.tabs.update(tabId, { url: '/lightning/search?searchInput=...' })
  → Salesforce 検索結果ページへ遷移
```

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `content.js` | search ハンドラを `sendMessage` 1行に置き換え（DOM操作・URL構築を除去） |
| `background.js` | `NAVIGATE_TO_SEARCH` case を追加 |
| `__tests__/unit/background.test.js` | NAVIGATE_TO_SEARCH のテスト2件を追加 |
| `__tests__/playwright/e2e-coverage.test.js` | テスト3-search-3〜5 を新フロー（sendMessage）に差し替え |

## テスト結果

- Jest: 624件 全 PASS ✅（2件増加）
- Playwright: 101件 全 PASS ✅
- Lint: エラー 0件 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)