### PR TITLE
fix(search): SW keepalive 即時送信 + NAVIGATE_TO_SEARCH sendResponse 修正

### DIFF
--- a/__tests__/unit/background.test.js
+++ b/__tests__/unit/background.test.js
@@ -138,6 +138,8 @@ describe('background.js', () => {
 
       const result = background.handleMessage(message, sender, sendResponse);
       expect(result).toBe(false);
+      // タブ遷移前に sendResponse が呼ばれること（message channel closed エラー防止）
+      expect(sendResponse).toHaveBeenCalledWith({ success: true });
       expect(chrome.tabs.update).toHaveBeenCalledWith(
         42,
         { url: 'https://myorg.my.salesforce.com/lightning/search?searchInput=ABC%E6%A0%AA%E5%BC%8F%E4%BC%9A%E7%A4%BE' }

--- a/background.js
+++ b/background.js
@@ -54,6 +54,8 @@ function handleMessage(message, sender, sendResponse) {
         sendResponse({ success: false, error: 'no tab' });
         return false;
       }
+      // タブ遷移前にレスポンスを送信（遷移後に message channel が閉じても lastError にならない）
+      sendResponse({ success: true });
       try {
         const tabOrigin = new URL(sender.tab.url).origin;
         const searchUrl = `${tabOrigin}/lightning/search?searchInput=${encodeURIComponent(keyword)}`;


### PR DESCRIPTION
## 根本原因と修正

### バグ1: keepalive タイマーが短い発話で一度も発火しない（主要原因）

`setInterval(fn, 10000)` の**初回発火は 10 秒後**。音声認識が 3〜8 秒で完了すると、keepalive は一度も送信されないまま `stopKeepalive()` でキャンセルされる。

```
t=0  startKeepalive() → setInterval 登録（初回発火は t+10s）
t=5  onResult → stopKeepalive() → タイマーキャンセル
     ↑ keepalive 未発火 → SW アイドル死亡 → セッションキー消失
t=5  GET_VALID_TOKEN → トークンエラー → /lightning/search へフォールバック遷移
     → /lightning/search がローディング画面で止まる
```

**修正**: `startKeepalive()` の先頭で即時 1 回 `STAY_ALIVE` を送信。
短い発話でも SW が確実に起動した状態でトークン取得できるようになる。

### バグ2: NAVIGATE_TO_SEARCH が sendResponse を呼ばない

`chrome.tabs.update` でタブが遷移すると message channel が閉じ、
新ページのコンソールに `Unchecked runtime.lastError: A listener indicated an asynchronous response by returning true, but the message channel closed...` 警告が表示される。

**修正**: `chrome.tabs.update` の前に `sendResponse({ success: true })` を呼ぶ。

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `content.js` | `startKeepalive()` に即時 STAY_ALIVE 追加 |
| `background.js` | NAVIGATE_TO_SEARCH に `sendResponse({ success: true })` 追加 |
| `background.test.js` | sendResponse が呼ばれることを検証するアサーション追加 |
| `e2e-coverage.test.js` | テスト3-search-9 を即時送信の検証に更新 |

## Test plan

- [x] `npm run lint` → 0 errors
- [x] `npm test` → 633件 PASS
- [x] `npx playwright test` → 105件 PASS
- [x] `npm run build` → dist/ ビルド成功
- [ ] 実機: Option+V → 「ABC株式会社を検索して」→ ウィジェットに「検索中...」→ SOSL 実行 → レコードページへ遷移（トークンエラーが出なくなることを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)