### PR TITLE
fix(auth): SW 再起動後のセッションキー不在を早期検出し再接続メッセージを表示

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -249,6 +249,16 @@ async function refreshAccessToken() {
 }
 
 async function getValidToken() {
+  // SW 再起動でセッションキーが消えた場合の早期検出。
+  // getOrCreateEncryptionKey() はキー不在時に「新しいキーを生成」してしまうため、
+  // 旧キーで暗号化されたトークンが復号不能になる前にチェックする。
+  const sessionData = await new Promise((resolve) => {
+    chrome.storage.session.get([STORAGE_KEYS.ENCRYPTION_KEY], (r) => resolve(r));
+  });
+  if (!sessionData[STORAGE_KEYS.ENCRYPTION_KEY]) {
+    throw new Error('セッションが切れました。ポップアップから再接続してください');
+  }
+
   const key = await getOrCreateEncryptionKey();
   const stored = await new Promise((resolve) => {
     chrome.storage.local.get([


### PR DESCRIPTION
## 根本原因

```
SW 再起動
  → chrome.storage.session 消去（セッションキー消失）
  → getOrCreateEncryptionKey() がキー不在 → 新しいランダムキーを生成
  → getValidToken() が「新キー」で旧トークンを復号
  → crypto.subtle.decrypt 失敗（キーが違う）
  → error.message が空の DOMException
  → content.js: r?.error || 'トークン取得に失敗しました'
  → /lightning/search へフォールバック遷移 → ローディング画面で止まる
```

## 修正

### lib/auth.js: getValidToken() にセッションキー存在チェックを追加

`getOrCreateEncryptionKey()` を呼ぶ前に `chrome.storage.session` を確認し、
キーが存在しない場合（SW 再起動後）は即座にエラーをスローする。

```javascript
// 追加箇所（getValidToken 先頭）
const sessionData = await new Promise((resolve) => {
  chrome.storage.session.get([STORAGE_KEYS.ENCRYPTION_KEY], (r) => resolve(r));
});
if (!sessionData[STORAGE_KEYS.ENCRYPTION_KEY]) {
  throw new Error('セッションが切れました。ポップアップから再接続してください');
}
```

### content.js: トークンエラー時は検索ページへ遷移しない

| 変更前 | 変更後 |
|-------|-------|
| `「ABC株式会社」を検索します（再接続を推奨）` + `/lightning/search` へ遷移（止まる） | `ポップアップから再接続してください` エラー表示（4秒後 idle） |

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `lib/auth.js` | `getValidToken()` にセッションキー存在チェックを追加 |
| `content.js` | トークンエラー時はエラー表示、`'セッション'` を `isTokenErr` 判定に追加 |
| `auth.test.js` | セッションキー不在テスト追加、既存テストを session key あり環境に更新 |

## Test plan

- [x] `npm run lint` → 0 errors
- [x] `npm test` → 634件 PASS（新テスト +1件）
- [x] `npx playwright test` → 105件 PASS
- [x] `npm run build` → dist/ ビルド成功
- [ ] 実機: Option+V → 「ABC株式会社を検索して」
  - SW が停止した状態から: ウィジェットに **「ポップアップから再接続してください」** が表示され、4秒後に idle に戻る（`/lightning/search` への遷移なし）
  - ポップアップで再接続後: SOSL 検索が正常に実行される

🤖 Generated with [Claude Code](https://claude.com/claude-code)