### PR TITLE
feat(ux): ヘルプコマンド実装・未認識コマンドのメッセージ改善

### DIFF
--- a/__tests__/unit/widget.test.js
+++ b/__tests__/unit/widget.test.js
@@ -255,6 +255,14 @@ describe('createWidget', () => {
       expect(el.style.display).toBe('none');
     });
 
+    test('duration: null のとき自動消滅しない（ヘルプ表示用）', () => {
+      widget.setState(STATES.SUCCESS, { message: 'ヘルプテキスト', duration: null });
+      const el = document.getElementById('vfa-widget');
+      jest.advanceTimersByTime(60000);
+      expect(el.style.display).toBe('block');
+      expect(widget.getState()).toBe(STATES.SUCCESS);
+    });
+
     test('getState() は success を返す', () => {
       widget.setState(STATES.SUCCESS, { message: '完了' });
       expect(widget.getState()).toBe(STATES.SUCCESS);

--- a/content.js
+++ b/content.js
@@ -198,6 +198,29 @@ if (isSalesforceUrl) {
           const sfObject = intent.object || 'Account';
           runSearch(keyword, sfObject);
 
+        } else if (intent && intent.action === 'help') {
+          const HELP_TEXT = [
+            '── 一覧を開く ──',
+            '「商談」「取引先」「リード」',
+            '「すべての商談を開いて」',
+            '「最近の商談を開いて」',
+            '「自分の商談を開いて」',
+            '',
+            '── レコードを検索 ──',
+            '「田中商事の商談を開いて」',
+            '「ABC株式会社を見せて」',
+            '「取引先でABCを検索して」',
+            '',
+            '── 候補が複数のとき ──',
+            '「1番」〜「5番」でレコードを選択',
+            '',
+            '── その他 ──',
+            '「戻って」「戻る」「バック」',
+            '「ヘルプ」でこの画面を再表示',
+          ].join('\n');
+          // duration: null で自動消滅しない（ユーザーが読み終えるまで表示）
+          w.setState('success', { message: HELP_TEXT, duration: null });
+
         } else if (intent && intent.action === 'select') {
           // 候補リスト表示中の音声番号選択（「1番」「2」など）
           if (pendingCandidates) {
@@ -220,7 +243,11 @@ if (isSalesforceUrl) {
           }
 
         } else {
-          w.setState('success', { message: `認識: ${transcript}` });
+          // ruleEngine にマッチしないコマンド → ユーザーに使い方を案内
+          w.setState('error', {
+            message: `「${transcript}」は未対応のコマンドです\n「ヘルプ」と言うと使い方を確認できます`,
+          });
+          setTimeout(() => w.setState('idle'), 4000);
         }
       },
       onError: (err) => {

--- a/ui/widget.js
+++ b/ui/widget.js
@@ -259,7 +259,10 @@ function createWidget() {
       messageEl.textContent = opts.message || '';
       const duration =
         opts.duration !== undefined ? opts.duration : DEFAULT_SUCCESS_DURATION_MS;
-      successTimer = setTimeout(() => setState(STATES.IDLE), duration);
+      // duration: null の場合は自動消滅しない（ヘルプ表示など、ユーザーが読み終えるまで残す用途）
+      if (duration !== null) {
+        successTimer = setTimeout(() => setState(STATES.IDLE), duration);
+      }
       return;
     }
 


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **#73** `「ヘルプ」` と発話すると使えるコマンド一覧をウィジェットに表示する
- **#74** ruleEngine にマッチしない発話を `「認識: …」`（success・緑）から `「未対応のコマンドです。ヘルプと言ってみてください」`（error・赤）に変更

## 変更内容

### `content.js`
- `intent.action === 'help'` ブランチを追加。コマンド一覧テキストを `duration: null` で自動消滅なし表示
- `else` ブランチを `error` state + ヘルプ誘導メッセージに変更（4秒後 idle）

### `ui/widget.js`
- `setState('success', { duration: null })` のとき `successTimer` をセットしない対応を追加

### テスト（698件、+6件）
- `widget.test.js`: `duration: null` で60秒経過しても自動消滅しないこと
- `voiceToAction.test.js`: ヘルプ intent 3件・未認識コマンド 2件

## Test plan

- [x] Jest 698件 全 PASS
- [x] Lint エラー 0
- [x] pre-push フック通過
- [ ] 実機: Salesforce で `Option+V` → 「ヘルプ」発話 → コマンド一覧表示
- [ ] 実機: 未対応発話で error（赤）ウィジェット表示 → 4秒後消える

Closes #73
Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)