### PR TITLE
feat(ux): EDITING状態を音声ファーストな動線に改善 (#77)

### DIFF
--- a/__tests__/unit/widget.test.js
+++ b/__tests__/unit/widget.test.js
@@ -419,15 +419,33 @@ describe('createWidget', () => {
       expect(onCancel).toHaveBeenCalled();
     });
 
-    test('60秒後 → ERROR → 3秒後 IDLE', () => {
+    test('30秒後 → ERROR → 3秒後 IDLE', () => {
       jest.useFakeTimers();
       widget.setState(STATES.EDITING, { keyword: 'テスト', sfObject: 'Account' });
       expect(widget.getState()).toBe(STATES.EDITING);
-      jest.advanceTimersByTime(60000);
+      jest.advanceTimersByTime(30000);
       expect(widget.getState()).toBe(STATES.ERROR);
       jest.advanceTimersByTime(3000);
       expect(widget.getState()).toBe(STATES.IDLE);
       jest.useRealTimers();
+    });
+
+    test('setState(editing) → ステータスが「見つかりませんでした」', () => {
+      widget.setState(STATES.EDITING, { keyword: 'テスト', sfObject: 'Account' });
+      const el = document.getElementById('vfa-widget');
+      expect(el.querySelector('.vfa-status').textContent).toBe('見つかりませんでした');
+    });
+
+    test('setState(editing) → メッセージに言い直しガイドが含まれる', () => {
+      widget.setState(STATES.EDITING, { keyword: 'テスト', sfObject: 'Account' });
+      const el = document.getElementById('vfa-widget');
+      expect(el.querySelector('.vfa-message').textContent).toContain('Alt+V');
+    });
+
+    test('setState(editing) → キャンセルボタンのラベルが「閉じる」', () => {
+      widget.setState(STATES.EDITING, { keyword: 'テスト', sfObject: 'Account' });
+      const el = document.getElementById('vfa-widget');
+      expect(el.querySelector('.vfa-btn-cancel').textContent).toBe('閉じる');
     });
 
     test('IDLE 遷移時に edit-row が非表示になる', () => {

--- a/content.css
+++ b/content.css
@@ -44,6 +44,7 @@
   margin-bottom: 4px;
   line-height: 1.5;
   word-break: break-all;
+  white-space: pre-line;
 }
 
 /* ── 確認ボタン群 ── */

--- a/ui/widget.js
+++ b/ui/widget.js
@@ -98,7 +98,7 @@ function createWidget() {
   const editCancelBtnEl = document.createElement('button');
   editCancelBtnEl.className = 'vfa-btn vfa-btn-cancel';
   editCancelBtnEl.setAttribute('type', 'button');
-  editCancelBtnEl.textContent = 'キャンセル';
+  editCancelBtnEl.textContent = '閉じる';
   editCancelBtnEl.style.display = 'none';
 
   container.appendChild(statusEl);
@@ -184,9 +184,9 @@ function createWidget() {
     }
 
     if (state === STATES.EDITING) {
-      statusEl.textContent = '見つかりません — 修正して再検索';
+      statusEl.textContent = '見つかりませんでした';
       transcriptEl.textContent = '';
-      messageEl.textContent = '';
+      messageEl.textContent = 'もう一度 Alt+V を押して言い直してください\n↓ または手動で修正 ↓';
       editInputEl.value = opts.keyword || '';
       editRowEl.style.display = 'flex';
       editCancelBtnEl.style.display = 'block';
@@ -230,11 +230,11 @@ function createWidget() {
         if (cancelCallback) cancelCallback();
       };
 
-      // 60秒タイムアウト
+      // 30秒タイムアウト
       editingTimeoutId = setTimeout(() => {
         setState(STATES.ERROR, { message: 'タイムアウトしました' });
         setTimeout(() => setState(STATES.IDLE), 3000);
-      }, 60000);
+      }, 30000);
 
       // オートフォーカス（カーソルを末尾に移動）
       editInputEl.focus();


### PR DESCRIPTION
## Summary

Issue #77 案A を採用。テキスト入力は補助として残しつつ「声で言い直す」を主動線にする。

- `ui/widget.js`: EDITING 状態のステータスを「見つかりません — 修正して再検索」→「見つかりませんでした」に変更
- `ui/widget.js`: メッセージに「もう一度 Alt+V を押して言い直してください」を追加（主動線）
- `ui/widget.js`: キャンセルボタンのラベルを「キャンセル」→「閉じる」に変更（押しやすく）
- `ui/widget.js`: タイムアウトを 60秒 → 30秒に短縮
- `content.css`: `.vfa-message` に `white-space: pre-line` を追加（改行表示）
- `__tests__/unit/widget.test.js`: タイムアウトテストを 30秒に更新 + 新規テスト3件追加

## テスト

- Lint: 0 errors（warnings のみ）
- Jest: 701件 PASS（+3件）

## 完了条件チェック

- [x] 0件時のウィジェットメッセージが「もう一度言い直してください」を主動線にしている
- [x] テキスト入力は補助として残っている（案A採用）
- [x] タイムアウトが 30秒
- [x] テスト更新済み

Closes #77