### PR TITLE
fix(popup): 404になるセットアップガイドリンクを削除

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -191,19 +191,6 @@
       word-break: break-all;
     }
 
-    .btn-guide {
-      width: 100%;
-      padding: 6px 12px;
-      border: 1px solid #93c5fd;
-      border-radius: 6px;
-      background: #fff;
-      font-size: 12px;
-      font-weight: 500;
-      color: #1d4ed8;
-      cursor: pointer;
-    }
-
-    .btn-guide:hover { background: #eff6ff; opacity: 1; }
   </style>
 </head>
 <body>
@@ -226,7 +213,6 @@
       <li>「コードフローの要件（PKCE）」を有効化</li>
       <li>保存後に表示される「コンシューマーキー」と「コンシューマーシークレット」を下に入力</li>
     </ol>
-    <button id="open-guide-btn" class="btn-guide">詳しいセットアップガイドを開く ↗</button>
   </div>
 
   <div id="connect-form" class="section">

--- a/popup.js
+++ b/popup.js
@@ -89,7 +89,3 @@ document.getElementById('customize-shortcut-btn').addEventListener('click', () =
   chrome.tabs.create({ url: 'chrome://extensions/shortcuts' });
 });
 
-// セットアップガイドを GitHub で開く
-document.getElementById('open-guide-btn').addEventListener('click', () => {
-  chrome.tabs.create({ url: 'https://github.com/iwasatat0107/voiceforce/blob/main/docs/setup-guide.md' });
-});


### PR DESCRIPTION
## Summary

- ポップアップの「詳しいセットアップガイドを開く ↗」ボタンを削除
- `docs/setup-guide.md` は `develop` にのみ存在し `main` に未マージのため、リンク先が 404 になっていた
- ポップアップ内のインライン手順（ol 4ステップ）で十分なためボタン自体を廃止

## 変更ファイル

- `popup.html`: ボタン要素・`.btn-guide` スタイルを削除
- `popup.js`: `open-guide-btn` のイベントハンドラを削除
