### PR TITLE
fix(content): トークンエラー時のメッセージを具体的な操作手順に改善

### DIFF
--- a/content.js
+++ b/content.js
@@ -139,8 +139,8 @@ if (isSalesforceUrl) {
           err.message.includes('closed') || err.message.includes('unauthorized') ||
           err.message.includes('INVALID_SESSION');
         if (isTokenErr) {
-          w.setState('error', { message: 'ポップアップから再接続してください' });
-          setTimeout(() => w.setState('idle'), 4000);
+          w.setState('error', { message: '接続が切れました\n① ツールバーの 🍤 をクリック\n② 「接続を解除」→「Salesforceに接続」' });
+          setTimeout(() => w.setState('idle'), 6000);
         } else {
           w.setState('error', { message: err.message || '検索中にエラーが発生しました' });
           setTimeout(() => w.setState('idle'), 3000);


### PR DESCRIPTION
## Summary

- トークンエラー時のウィジェットメッセージを「ポップアップから再接続してください」から具体的な3ステップに変更
- 表示時間を 4秒 → 6秒に延長（3行読み終える時間を確保）

**変更前:**
```
ポップアップから再接続してください
```

**変更後:**
```
接続が切れました
① ツールバーの 🍤 をクリック
② 「接続を解除」→「Salesforceに接続」
```

Closes #85
