### PR TITLE
feat(intent): LLM（intentResolver）を content.js に接続する (#76)

### DIFF
--- a/__tests__/integration/voiceToAction.test.js
+++ b/__tests__/integration/voiceToAction.test.js
@@ -6,6 +6,7 @@ const { resolve, RESULT_CATEGORY }         = require('../../lib/recordResolver')
 const { createWidget, STATES }             = require('../../ui/widget');
 const { createCandidateList }              = require('../../ui/candidateList');
 const { OBJECT_DISPLAY_FIELDS }            = require('../../lib/salesforceApi');
+const { validateLLMOutput, resolveIntent } = require('../../lib/intentResolver');
 
 const INSTANCE_URL = 'https://example.lightning.force.com';
 
@@ -282,6 +283,82 @@ describe('音声→アクション統合テスト', () => {
 
       w.destroy();
       jest.useRealTimers();
+    });
+  });
+
+  // ── LLM フォールバック（#76）─────────────────────────────────────────────
+  describe('LLMフォールバック（#76）', () => {
+    const WORKER_URL = 'https://voiceforce-worker.iwasatat0107.workers.dev';
+    const USER_ID    = 'ext-test-user';
+
+    beforeEach(() => {
+      global.fetch = jest.fn();
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    test('ruleEngine が null → resolveIntent を呼び出し navigate レスポンスを受け取る', async () => {
+      const llmResponse = { action: 'navigate', target: 'list', object: 'Opportunity', confidence: 0.92, message: '商談一覧を開きます' };
+      global.fetch.mockResolvedValueOnce({ ok: true, json: async () => llmResponse });
+
+      const result = await resolveIntent('パイプラインを見せて', '', WORKER_URL, USER_ID);
+      expect(result.action).toBe('navigate');
+      expect(result.object).toBe('Opportunity');
+      expect(validateLLMOutput(result, null)).toBe(true);
+    });
+
+    test('resolveIntent が search レスポンスを返す → validateLLMOutput が true を返す', async () => {
+      const llmResponse = { action: 'search', object: 'Account', search_term: '田中商事', confidence: 0.88 };
+      global.fetch.mockResolvedValueOnce({ ok: true, json: async () => llmResponse });
+
+      const result = await resolveIntent('田中商事を調べて', '', WORKER_URL, USER_ID);
+      expect(validateLLMOutput(result, null)).toBe(true);
+      expect(result.search_term).toBe('田中商事');
+    });
+
+    test('resolveIntent が unknown レスポンスを返す → validateLLMOutput が true を返す', async () => {
+      const llmResponse = { action: 'unknown', confidence: 0.1, message: '操作を認識できませんでした' };
+      global.fetch.mockResolvedValueOnce({ ok: true, json: async () => llmResponse });
+
+      const result = await resolveIntent('今日の天気は？', '', WORKER_URL, USER_ID);
+      expect(validateLLMOutput(result, null)).toBe(true);
+      expect(result.action).toBe('unknown');
+    });
+
+    test('LLM が不正なaction（"delete"）を返した場合 validateLLMOutput が false を返す', async () => {
+      const injectedResponse = { action: 'delete', object: 'Account', confidence: 0.9 };
+      global.fetch.mockResolvedValueOnce({ ok: true, json: async () => injectedResponse });
+
+      const result = await resolveIntent('テスト', '', WORKER_URL, USER_ID);
+      expect(validateLLMOutput(result, null)).toBe(false);
+    });
+
+    test('Worker が 429 を返した場合エラーに .status=429 が付与される', async () => {
+      global.fetch.mockResolvedValueOnce({
+        ok: false, status: 429,
+        json: async () => ({ error: 'Rate limit exceeded. Please try again later.' }),
+      });
+
+      let err;
+      try { await resolveIntent('テスト', '', WORKER_URL, USER_ID); }
+      catch (e) { err = e; }
+      expect(err).toBeDefined();
+      expect(err.status).toBe(429);
+    });
+
+    test('ネットワークエラー時は Error がスローされる', async () => {
+      global.fetch.mockRejectedValueOnce(new Error('fetch failed'));
+      await expect(resolveIntent('テスト', '', WORKER_URL, USER_ID))
+        .rejects.toThrow('fetch failed');
+    });
+
+    test('LLMフォールバックの入口: ruleEngine が null を返す発話の確認', () => {
+      // これらの発話は ruleEngine ではハンドルできない → LLM フォールバックへ
+      expect(match('今月のパイプラインを教えて')).toBeNull();
+      expect(match('山田さんの商談を更新して')).toBeNull();
+      expect(match('')).toBeNull();
     });
   });
 

--- a/__tests__/unit/manifest.test.js
+++ b/__tests__/unit/manifest.test.js
@@ -90,6 +90,7 @@ describe('manifest.json', () => {
       'lib/speechRecognition.js':  'createSpeechRecognition()',
       'lib/salesforceApi.js':      'soslFuzzy()',
       'lib/recordResolver.js':     'resolve()',
+      'lib/intentResolver.js':     'resolveIntent() / validateLLMOutput()',
       'ui/widget.js':              'createWidget()',
       'ui/candidateList.js':       'createCandidateList()',
     };

--- a/content.js
+++ b/content.js
@@ -13,6 +13,10 @@ if (isSalesforceUrl) {
   let pendingCandidates = null; // { records, sfObject, instanceUrl }
   let toggleCooldown = false;   // 連続押し防止（500ms デバウンス）
 
+  // Cloudflare Worker URL（LLM フォールバック用）
+  // デプロイ後は実際のURLに更新してください
+  const WORKER_URL = 'https://voiceforce-worker.iwasatat0107.workers.dev';
+
   // 検索対象オブジェクトごとの取得フィールド（Task は Name の代わりに Subject を使用）
   const OBJECT_DISPLAY_FIELDS = {
     'Account':     ['Id', 'Name'],
@@ -266,11 +270,76 @@ if (isSalesforceUrl) {
           }
 
         } else {
-          // ruleEngine にマッチしないコマンド → ユーザーに使い方を案内
-          w.setState('error', {
-            message: `「${transcript}」は未対応のコマンドです\n「ヘルプ」と言うと使い方を確認できます`,
-          });
-          setTimeout(() => w.setState('idle'), 4000);
+          // ruleEngine にマッチしない → LLM（intentResolver）にフォールバック
+          w.setState('processing', { message: 'AI解析中...' });
+          const userId = chrome.runtime.id;
+          const llmTimeout = new Promise((_, reject) =>
+            setTimeout(() => {
+              const e = new Error('timeout');
+              e.isTimeout = true;
+              reject(e);
+            }, 10000)
+          );
+          Promise.race([
+            resolveIntent(transcript, '', WORKER_URL, userId), // eslint-disable-line no-undef
+            llmTimeout,
+          ])
+            .then((llmIntent) => {
+              if (!validateLLMOutput(llmIntent, null)) { // eslint-disable-line no-undef
+                w.setState('error', {
+                  message: '解析に失敗しました\n「ヘルプ」と言うと使い方を確認できます',
+                });
+                setTimeout(() => w.setState('idle'), 4000);
+                return;
+              }
+              if (llmIntent.action === 'navigate' && llmIntent.target === 'list') {
+                chrome.storage.local.get(['instance_url'], (result) => {
+                  const instanceUrl = result.instance_url || window.location.origin;
+                  const url = buildListUrl(instanceUrl, llmIntent.object, llmIntent.filterName); // eslint-disable-line no-undef
+                  w.setState('success', { message: llmIntent.message || '一覧を開きます' });
+                  setTimeout(() => navigateTo(url), 1000); // eslint-disable-line no-undef
+                });
+              } else if (llmIntent.action === 'search') {
+                const keyword = llmIntent.search_term || llmIntent.keyword;
+                const sfObject = llmIntent.object || 'Account';
+                if (keyword) {
+                  runSearch(keyword, sfObject);
+                } else {
+                  w.setState('error', {
+                    message: '検索キーワードが認識できませんでした\nもう一度お試しください',
+                  });
+                  setTimeout(() => w.setState('idle'), 3000);
+                }
+              } else if (llmIntent.action === 'unknown' || llmIntent.confidence < 0.5) {
+                w.setState('error', {
+                  message: llmIntent.message ||
+                    `「${transcript}」は認識できませんでした\n「ヘルプ」と言うと使い方を確認できます`,
+                });
+                setTimeout(() => w.setState('idle'), 4000);
+              } else {
+                // create / update / summary → 近日対応予定
+                w.setState('error', {
+                  message: 'この機能は近日対応予定です\n「ヘルプ」と言うと使い方を確認できます',
+                });
+                setTimeout(() => w.setState('idle'), 4000);
+              }
+            })
+            .catch((err) => {
+              if (err.isTimeout) {
+                w.setState('error', {
+                  message: '応答に時間がかかっています\nもう一度お試しください',
+                });
+              } else if (err.status === 429) {
+                w.setState('error', {
+                  message: '本日の音声解析の利用上限（10回）に達しました',
+                });
+              } else {
+                w.setState('error', {
+                  message: '解析に失敗しました\n「ヘルプ」と言うと使い方を確認できます',
+                });
+              }
+              setTimeout(() => w.setState('idle'), 4000);
+            });
         }
       },
       onError: (err) => {

--- a/manifest.json
+++ b/manifest.json
@@ -30,6 +30,7 @@
         "lib/speechRecognition.js",
         "lib/salesforceApi.js",
         "lib/recordResolver.js",
+        "lib/intentResolver.js",
         "ui/widget.js",
         "ui/candidateList.js",
         "content.js"


### PR DESCRIPTION
## Summary

- `lib/intentResolver.js` を `manifest.json` の content_scripts に追加
- `content.js` の ruleEngine miss 時の `else` ブロックを LLM フォールバックに置き換え
- `WORKER_URL` 定数を追加（`https://voiceforce-worker.iwasatat0107.workers.dev`）
- `manifest.test.js` REQUIRED_PROVIDERS に `lib/intentResolver.js` を追加
- `voiceToAction.test.js` に LLMフォールバック統合テスト 7件追加

## LLM フォールバックの動作

ruleEngine が null を返した発話に対して以下のフローで処理:

1. `w.setState('processing', { message: 'AI解析中...' })` で状態更新
2. `resolveIntent(transcript, '', WORKER_URL, userId)` を Cloudflare Worker に送信（10秒タイムアウト）
3. `validateLLMOutput` でホワイトリスト検証（プロンプトインジェクション防止）
4. アクション別処理:
   - `navigate(list)` → 既存ハンドラと同等の処理
   - `search` → `runSearch()` に委譲
   - `unknown` / `confidence < 0.5` → 「認識できませんでした」エラー
   - `create` / `update` / `summary` → 「近日対応予定」メッセージ
5. エラーハンドリング:
   - 429 → 「本日の利用上限（10回）に達しました」
   - timeout → 「応答に時間がかかっています。もう一度お試しください」
   - その他 → 「解析に失敗しました」

## Test plan

- [x] `npm run lint` — エラー 0件（warning 4件のみ）
- [x] `npm test` — 710件全 PASS
- [x] pre-push フック通過
- [ ] 実機テスト: Salesforce で ruleEngine 非対応の発話（「今月のパイプラインを教えて」等）で LLM が呼ばれることを確認

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)