### PR TITLE
feat(create): 取引先（Account）を音声で作成する (#92)

### DIFF
--- a/__tests__/integration/voiceToAction.test.js
+++ b/__tests__/integration/voiceToAction.test.js
@@ -362,6 +362,84 @@ describe('音声→アクション統合テスト', () => {
     });
   });
 
+  // ── レコード作成フロー（#92）──────────────────────────────────────────────
+  describe('レコード作成フロー（#92）', () => {
+    let widget;
+
+    beforeEach(() => {
+      const existing = document.getElementById('vfa-widget');
+      if (existing) existing.remove();
+      widget = createWidget();
+    });
+
+    afterEach(() => {
+      widget.destroy();
+    });
+
+    test('STATES.FIELD_INPUT が定義されている', () => {
+      expect(STATES.FIELD_INPUT).toBe('field-input');
+    });
+
+    test('LLM create レスポンス（Name あり）→ confirm 状態に遷移できる', () => {
+      const llmIntent = { action: 'create', object: 'Account', fields: { Name: 'ABC株式会社' }, missing_fields: [], confidence: 0.9 };
+      // missing_fields が空のとき → confirm 状態へ
+      widget.setState(STATES.CONFIRM, {
+        message: `取引先を作成します\n─────\n取引先名: ${llmIntent.fields.Name}\n─────\n「はい」で確定`,
+        onConfirm: jest.fn(),
+      });
+      expect(widget.getState()).toBe(STATES.CONFIRM);
+    });
+
+    test('LLM create レスポンス（Name なし）→ field-input 状態に遷移できる', () => {
+      const llmIntent = { action: 'create', object: 'Account', fields: {}, missing_fields: ['Name'], confidence: 0.8 };
+      widget.setState(STATES.FIELD_INPUT, {
+        fields: llmIntent.missing_fields.map(key => ({ label: key === 'Name' ? '取引先名' : key, key, value: '' })),
+        onSubmit: jest.fn(),
+        onCancel: jest.fn(),
+      });
+      expect(widget.getState()).toBe(STATES.FIELD_INPUT);
+      const el = document.getElementById('vfa-widget');
+      const inputs = el.querySelectorAll('.vfa-field-form input');
+      expect(inputs.length).toBe(1);
+      expect(inputs[0].getAttribute('data-key')).toBe('Name');
+    });
+
+    test('field-input で値を入力して確定 → onSubmit が呼ばれる', () => {
+      const onSubmit = jest.fn();
+      widget.setState(STATES.FIELD_INPUT, {
+        fields: [{ label: '取引先名', key: 'Name', value: '' }],
+        onSubmit,
+        onCancel: jest.fn(),
+      });
+      const el = document.getElementById('vfa-widget');
+      const input = el.querySelector('.vfa-field-form input[data-key="Name"]');
+      input.value = 'テスト株式会社';
+      el.querySelector('.vfa-btn-field-submit').click();
+      expect(onSubmit).toHaveBeenCalledWith({ Name: 'テスト株式会社' });
+    });
+
+    test('confirm の「はい」クリックで onConfirm(true) が呼ばれる', () => {
+      const onConfirm = jest.fn();
+      widget.setState(STATES.CONFIRM, { message: '取引先を作成します', onConfirm });
+      const el = document.getElementById('vfa-widget');
+      el.querySelector('.vfa-btn-yes').click();
+      expect(onConfirm).toHaveBeenCalledWith(true);
+    });
+
+    test('confirm の「いいえ」クリックで onConfirm(false) が呼ばれる', () => {
+      const onConfirm = jest.fn();
+      widget.setState(STATES.CONFIRM, { message: '取引先を作成します', onConfirm });
+      const el = document.getElementById('vfa-widget');
+      el.querySelector('.vfa-btn-no').click();
+      expect(onConfirm).toHaveBeenCalledWith(false);
+    });
+
+    test('validateLLMOutput: create レスポンス（object あり）はホワイトリストを通過する', () => {
+      const llmIntent = { action: 'create', object: 'Account', fields: { Name: 'ABC' }, missing_fields: [], confidence: 0.9 };
+      expect(validateLLMOutput(llmIntent, null)).toBe(true);
+    });
+  });
+
   // ── 未認識コマンド（#74）──────────────────────────────────────────────────
   describe('未認識コマンド（#74）', () => {
     test('ruleEngine にマッチしない発話は null を返す', () => {

--- a/__tests__/unit/widget.test.js
+++ b/__tests__/unit/widget.test.js
@@ -585,5 +585,119 @@ describe('createWidget', () => {
       const el = document.getElementById('vfa-widget');
       expect(el.querySelector('.vfa-confirm').style.display).toBe('none');
     });
+
+    test('processing → field-input へ遷移できる', () => {
+      widget.setState(STATES.PROCESSING);
+      widget.setState(STATES.FIELD_INPUT, {
+        fields: [{ label: '取引先名', key: 'Name', value: '' }],
+        onSubmit: jest.fn(),
+      });
+      expect(widget.getState()).toBe(STATES.FIELD_INPUT);
+    });
+
+    test('field-input → confirm へ遷移できる', () => {
+      widget.setState(STATES.FIELD_INPUT, {
+        fields: [{ label: '取引先名', key: 'Name', value: '' }],
+        onSubmit: jest.fn(),
+      });
+      widget.setState(STATES.CONFIRM, { message: '作成しますか？', onConfirm: jest.fn() });
+      expect(widget.getState()).toBe(STATES.CONFIRM);
+    });
+  });
+
+  // ──────────────────────────────────────
+  // field-input 状態（#92 レコード作成）
+  // ──────────────────────────────────────
+  describe('field-input 状態', () => {
+    const fields = [
+      { label: '取引先名', key: 'Name', value: '' },
+      { label: '電話番号', key: 'Phone', value: '03-1234-5678' },
+    ];
+    let onSubmit;
+    let onCancel;
+
+    beforeEach(() => {
+      onSubmit = jest.fn();
+      onCancel = jest.fn();
+      widget.setState(STATES.FIELD_INPUT, { fields, onSubmit, onCancel });
+    });
+
+    test('STATES.FIELD_INPUT が定義されている', () => {
+      expect(STATES.FIELD_INPUT).toBe('field-input');
+    });
+
+    test('getState() は field-input を返す', () => {
+      expect(widget.getState()).toBe(STATES.FIELD_INPUT);
+    });
+
+    test('ウィジェットが表示される', () => {
+      const el = document.getElementById('vfa-widget');
+      expect(el.style.display).toBe('block');
+    });
+
+    test('フィールド数分の input 要素が生成される', () => {
+      const el = document.getElementById('vfa-widget');
+      const inputs = el.querySelectorAll('.vfa-field-form input');
+      expect(inputs.length).toBe(fields.length);
+    });
+
+    test('各 input に data-key と初期値がセットされる', () => {
+      const el = document.getElementById('vfa-widget');
+      const inputs = el.querySelectorAll('.vfa-field-form input');
+      expect(inputs[0].getAttribute('data-key')).toBe('Name');
+      expect(inputs[0].value).toBe('');
+      expect(inputs[1].getAttribute('data-key')).toBe('Phone');
+      expect(inputs[1].value).toBe('03-1234-5678');
+    });
+
+    test('確定ボタンをクリックすると onSubmit が各フィールドの値で呼ばれる', () => {
+      const el = document.getElementById('vfa-widget');
+      const inputs = el.querySelectorAll('.vfa-field-form input');
+      inputs[0].value = 'ABC株式会社';
+      inputs[1].value = '03-9999-0000';
+      el.querySelector('.vfa-btn-field-submit').click();
+      expect(onSubmit).toHaveBeenCalledWith({ Name: 'ABC株式会社', Phone: '03-9999-0000' });
+    });
+
+    test('キャンセルボタンをクリックすると onCancel が呼ばれる', () => {
+      const el = document.getElementById('vfa-widget');
+      el.querySelector('.vfa-btn-field-cancel').click();
+      expect(onCancel).toHaveBeenCalledTimes(1);
+    });
+
+    test('idle へ遷移すると field-form が非表示になる', () => {
+      widget.setState(STATES.IDLE);
+      const el = document.getElementById('vfa-widget');
+      expect(el.querySelector('.vfa-field-form').style.display).toBe('none');
+    });
+
+    test('onSubmit なしでも確定クリックしてもエラーにならない', () => {
+      widget.setState(STATES.FIELD_INPUT, {
+        fields: [{ label: '名前', key: 'Name', value: '' }],
+      });
+      const el = document.getElementById('vfa-widget');
+      expect(() => el.querySelector('.vfa-btn-field-submit').click()).not.toThrow();
+    });
+
+    test('空文字の値は onSubmit に渡されない（フィルタなし: 値をそのまま渡す）', () => {
+      const el = document.getElementById('vfa-widget');
+      const inputs = el.querySelectorAll('.vfa-field-form input');
+      inputs[0].value = 'ABC株式会社';
+      inputs[1].value = ''; // 空のまま
+      el.querySelector('.vfa-btn-field-submit').click();
+      expect(onSubmit).toHaveBeenCalledWith({ Name: 'ABC株式会社', Phone: '' });
+    });
+
+    test('再度 field-input 状態にすると前の input がクリアされ新しい input に置き換わる', () => {
+      widget.setState(STATES.FIELD_INPUT, {
+        fields: [{ label: '新しいフィールド', key: 'NewField', value: '初期値' }],
+        onSubmit: jest.fn(),
+      });
+      const el = document.getElementById('vfa-widget');
+      const inputs = el.querySelectorAll('.vfa-field-form input');
+      expect(inputs.length).toBe(1);
+      expect(inputs[0].getAttribute('data-key')).toBe('NewField');
+      expect(inputs[0].value).toBe('初期値');
+    });
   });
 });

--- a/content.js
+++ b/content.js
@@ -17,6 +17,36 @@ if (isSalesforceUrl) {
   // デプロイ後は実際のURLに更新してください
   const WORKER_URL = 'https://voiceforce-worker.iwasatat0107.workers.dev';
 
+  // オブジェクト日本語ラベル
+  const SF_OBJECT_LABELS = {
+    'Account':     '取引先',
+    'Contact':     '取引先責任者',
+    'Lead':        'リード',
+    'Opportunity': '商談',
+    'Task':        'ToDo',
+  };
+
+  // フィールド日本語ラベル（代表的な標準フィールド）
+  const SF_FIELD_LABELS = {
+    'Name':         '取引先名',
+    'Phone':        '電話番号',
+    'Industry':     '業種',
+    'BillingState': '都道府県',
+    'FirstName':    '名',
+    'LastName':     '姓',
+    'Email':        'メールアドレス',
+    'Company':      '会社名',
+    'StageName':    'フェーズ',
+    'CloseDate':    '完了予定日',
+    'Amount':       '金額',
+    'Subject':      'タイトル',
+    'Status':       'ステータス',
+    'ActivityDate': '期日',
+    'AccountId':    '取引先',
+    'WhoId':        '関連する人',
+    'WhatId':       '関連するレコード',
+  };
+
   // 検索対象オブジェクトごとの取得フィールド（Task は Name の代わりに Subject を使用）
   const OBJECT_DISPLAY_FIELDS = {
     'Account':     ['Id', 'Name'],
@@ -152,6 +182,123 @@ if (isSalesforceUrl) {
         }
       }
     });
+  };
+
+  // アクセストークン取得ヘルパー
+  const getToken = function() {
+    return new Promise((tokenRes, tokenRej) => {
+      chrome.runtime.sendMessage({ type: 'GET_VALID_TOKEN' }, (r) => {
+        if (chrome.runtime.lastError) {
+          tokenRej(new Error(chrome.runtime.lastError.message));
+          return;
+        }
+        if (r && r.success) { tokenRes(r.token); return; }
+        tokenRej(new Error(r?.error || 'トークン取得に失敗しました'));
+      });
+    });
+  };
+
+  // トークンエラー判定・ウィジェット表示ヘルパー
+  const handleApiError = function(err) {
+    const w = getWidget();
+    const isTokenErr = !err.message ||
+      err.message.includes('セッション') || err.message.includes('トークン') ||
+      err.message.includes('token') || err.message.includes('Receiving end') ||
+      err.message.includes('message channel') || err.message.includes('closed') ||
+      err.message.includes('unauthorized') || err.message.includes('INVALID_SESSION');
+    if (isTokenErr) {
+      w.setState('error', { message: '接続が切れました\n① ツールバーの 🍤 をクリック\n② 「接続を解除」→「Salesforceに接続」' });
+      setTimeout(() => w.setState('idle'), 6000);
+    } else {
+      w.setState('error', { message: err.message || 'エラーが発生しました' });
+      setTimeout(() => w.setState('idle'), 3000);
+    }
+  };
+
+  // レコード作成実行（API コール → 成功なら作成レコードに遷移）
+  const executeCreate = function(sfObject, fields) {
+    const w = getWidget();
+    w.setState('processing', { message: '作成中...' });
+    chrome.storage.local.get(['instance_url'], async (result) => {
+      const instanceUrl = result.instance_url || window.location.origin;
+      try {
+        const token = await getToken();
+        const sfResult = await createRecord(instanceUrl, token, sfObject, fields); // eslint-disable-line no-undef
+        const url = buildRecordUrl(instanceUrl, sfObject, sfResult.id); // eslint-disable-line no-undef
+        const label = SF_OBJECT_LABELS[sfObject] || sfObject;
+        w.setState('success', { message: `${label}を作成しました` });
+        setTimeout(() => navigateTo(url), 1000); // eslint-disable-line no-undef
+      } catch (err) {
+        console.warn('[VF] createRecord error:', err.message, err.sfErrorCode);
+        if (err.sfErrorCode === 'REQUIRED_FIELD_MISSING') {
+          w.setState('error', { message: `必須項目が不足しています\n${err.message || ''}` });
+          setTimeout(() => w.setState('idle'), 5000);
+        } else if (err.sfErrorCode === 'DUPLICATES_DETECTED') {
+          w.setState('confirm', {
+            message: '似たレコードがすでに存在します\nそれでも作成しますか？',
+            onConfirm: (confirmed) => {
+              if (!confirmed) { w.setState('idle'); return; }
+              executeCreate(sfObject, Object.assign({}, fields, { AllowSave: true }));
+            },
+          });
+        } else if (err.sfErrorCode === 'FIELD_CUSTOM_VALIDATION_EXCEPTION') {
+          w.setState('error', { message: `入力規則エラー:\n${err.message}` });
+          setTimeout(() => w.setState('idle'), 5000);
+        } else {
+          handleApiError(err);
+        }
+      }
+    });
+  };
+
+  // 確認画面を表示してから作成実行
+  const showCreateConfirm = function(sfObject, fields) {
+    const w = getWidget();
+    const label = SF_OBJECT_LABELS[sfObject] || sfObject;
+    const fieldSummary = Object.entries(fields)
+      .map(([k, v]) => `${SF_FIELD_LABELS[k] || k}: ${v}`)
+      .join('\n');
+    w.setState('confirm', {
+      message: `${label}を作成します\n─────\n${fieldSummary}\n─────\n「はい」で確定`,
+      onConfirm: (confirmed) => {
+        if (!confirmed) { w.setState('idle'); return; }
+        executeCreate(sfObject, fields);
+      },
+    });
+  };
+
+  // LLM create アクション処理
+  const handleCreate = function(llmIntent) {
+    const w = getWidget();
+    const sfObject = llmIntent.object;
+    if (!sfObject) {
+      w.setState('error', { message: '作成するオブジェクトが認識できませんでした\n「ヘルプ」と言うと使い方を確認できます' });
+      setTimeout(() => w.setState('idle'), 4000);
+      return;
+    }
+
+    const fields = llmIntent.fields || {};
+    const missingFields = llmIntent.missing_fields || [];
+
+    if (missingFields.length > 0) {
+      const label = SF_OBJECT_LABELS[sfObject] || sfObject;
+      w.setState('field-input', {
+        message: `${label}に必要な情報を入力してください`,
+        fields: missingFields.map((key) => ({
+          label: SF_FIELD_LABELS[key] || key,
+          key,
+          value: fields[key] || '',
+        })),
+        onSubmit: (values) => {
+          const allFields = Object.assign({}, fields);
+          Object.entries(values).forEach(([k, v]) => { if (v) allFields[k] = v; });
+          showCreateConfirm(sfObject, allFields);
+        },
+        onCancel: () => { w.setState('idle'); },
+      });
+    } else {
+      showCreateConfirm(sfObject, fields);
+    }
   };
 
   const SPEECH_ERROR_MESSAGES = {
@@ -316,8 +463,10 @@ if (isSalesforceUrl) {
                     `「${transcript}」は認識できませんでした\n「ヘルプ」と言うと使い方を確認できます`,
                 });
                 setTimeout(() => w.setState('idle'), 4000);
+              } else if (llmIntent.action === 'create') {
+                handleCreate(llmIntent);
               } else {
-                // create / update / summary → 近日対応予定
+                // update / summary → 近日対応予定
                 w.setState('error', {
                   message: 'この機能は近日対応予定です\n「ヘルプ」と言うと使い方を確認できます',
                 });

--- a/ui/widget.js
+++ b/ui/widget.js
@@ -4,14 +4,15 @@
 // XSS防止のため innerHTML は使用しない。テキストは textContent のみ使用。
 
 const STATES = {
-  IDLE:       'idle',
-  LISTENING:  'listening',
-  PROCESSING: 'processing',
-  EDITING:    'editing',
-  CONFIRM:    'confirm',
-  SUCCESS:    'success',
-  ERROR:      'error',
-  SELECTING:  'selecting', // candidateList 選択待ち（自動消滅なし）
+  IDLE:        'idle',
+  LISTENING:   'listening',
+  PROCESSING:  'processing',
+  EDITING:     'editing',
+  CONFIRM:     'confirm',
+  FIELD_INPUT: 'field-input', // レコード作成時の必須項目入力フォーム
+  SUCCESS:     'success',
+  ERROR:       'error',
+  SELECTING:   'selecting', // candidateList 選択待ち（自動消滅なし）
 };
 
 const DEFAULT_SUCCESS_DURATION_MS = 3000;
@@ -101,6 +102,21 @@ function createWidget() {
   editCancelBtnEl.textContent = '閉じる';
   editCancelBtnEl.style.display = 'none';
 
+  // field-input フォームコンテナ（レコード作成時の必須項目入力）
+  const fieldFormEl = document.createElement('div');
+  fieldFormEl.className = 'vfa-field-form';
+  fieldFormEl.style.display = 'none';
+
+  const fieldFormSubmitBtn = document.createElement('button');
+  fieldFormSubmitBtn.className = 'vfa-btn vfa-btn-field-submit';
+  fieldFormSubmitBtn.setAttribute('type', 'button');
+  fieldFormSubmitBtn.textContent = '確定';
+
+  const fieldFormCancelBtn = document.createElement('button');
+  fieldFormCancelBtn.className = 'vfa-btn vfa-btn-field-cancel';
+  fieldFormCancelBtn.setAttribute('type', 'button');
+  fieldFormCancelBtn.textContent = 'キャンセル';
+
   container.appendChild(statusEl);
   container.appendChild(transcriptEl);
   container.appendChild(messageEl);
@@ -108,6 +124,7 @@ function createWidget() {
   container.appendChild(editRowEl);
   container.appendChild(objectRowEl);
   container.appendChild(editCancelBtnEl);
+  container.appendChild(fieldFormEl);
 
   document.body.appendChild(container);
 
@@ -156,6 +173,9 @@ function createWidget() {
     editRowEl.style.display = 'none';
     objectRowEl.style.display = 'none';
     editCancelBtnEl.style.display = 'none';
+
+    // field-input フォームをリセット
+    fieldFormEl.style.display = 'none';
 
     if (state === STATES.IDLE) {
       container.style.display = 'none';
@@ -240,6 +260,60 @@ function createWidget() {
       editInputEl.focus();
       const len = editInputEl.value.length;
       editInputEl.setSelectionRange(len, len);
+      return;
+    }
+
+    if (state === STATES.FIELD_INPUT) {
+      statusEl.textContent = '入力が必要です';
+      messageEl.textContent = opts.message || '不足している情報を入力してください';
+
+      // 既存の入力欄をクリアして再構築（XSS防止: DOM API のみ使用）
+      while (fieldFormEl.firstChild) fieldFormEl.removeChild(fieldFormEl.firstChild);
+
+      const fieldDefs = opts.fields || [];
+      const inputRefs = {};
+
+      fieldDefs.forEach(({ label, key, value }) => {
+        const rowEl = document.createElement('div');
+        rowEl.className = 'vfa-field-row';
+
+        const labelEl = document.createElement('label');
+        labelEl.className = 'vfa-field-label';
+        labelEl.textContent = label;
+
+        const inputEl = document.createElement('input');
+        inputEl.type = 'text';
+        inputEl.className = 'vfa-field-input-item';
+        inputEl.value = (value !== undefined && value !== null) ? String(value) : '';
+        inputEl.setAttribute('data-key', key);
+        inputRefs[key] = inputEl;
+
+        rowEl.appendChild(labelEl);
+        rowEl.appendChild(inputEl);
+        fieldFormEl.appendChild(rowEl);
+      });
+
+      fieldFormEl.appendChild(fieldFormSubmitBtn);
+      fieldFormEl.appendChild(fieldFormCancelBtn);
+      fieldFormEl.style.display = 'block';
+
+      fieldFormSubmitBtn.onclick = () => {
+        const values = {};
+        fieldDefs.forEach(({ key }) => {
+          values[key] = inputRefs[key] ? inputRefs[key].value.trim() : '';
+        });
+        if (opts.onSubmit) opts.onSubmit(values);
+      };
+
+      fieldFormCancelBtn.onclick = () => {
+        if (opts.onCancel) opts.onCancel();
+      };
+
+      // オートフォーカス（最初のフィールド）
+      const firstKey = fieldDefs[0] && fieldDefs[0].key;
+      if (firstKey && inputRefs[firstKey]) {
+        inputRefs[firstKey].focus();
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary

- `ui/widget.js`: `FIELD_INPUT` 状態を追加（レコード作成時の必須項目入力フォーム）
- `content.js`: LLM `create` アクション処理を実装
- `widget.test.js`: field-input 状態テスト 10件追加
- `voiceToAction.test.js`: レコード作成フロー統合テスト 6件追加

## 実装内容

### widget.js: FIELD_INPUT 状態
```javascript
// 使用例
widget.setState(STATES.FIELD_INPUT, {
  fields: [{ label: '取引先名', key: 'Name', value: '' }],
  onSubmit: (values) => { /* values = { Name: '...' } */ },
  onCancel: () => { widget.setState('idle'); },
});
```
- DOM API のみ使用（innerHTML 禁止・XSS 防止）
- 再設定時に既存 input をクリアして再構築

### content.js: create フロー
```
LLM → { action: 'create', object: 'Account', fields: {Name: 'ABC'}, missing_fields: [] }
  └─ missing_fields あり → field-input（不足項目の入力フォーム）
  └─ missing_fields なし → confirm（「ABC株式会社を作成します。はい/いいえ」）
       └─ はい → createRecord API → 作成レコードページに遷移
       └─ いいえ → idle
```

### エラーハンドリング
| エラーコード | 対応 |
|---|---|
| `REQUIRED_FIELD_MISSING` | 「必須項目が不足しています」エラー表示 |
| `DUPLICATES_DETECTED` | 「似たレコードがすでに存在します。それでも作成しますか？」確認 → AllowSave で再送 |
| `FIELD_CUSTOM_VALIDATION_EXCEPTION` | Salesforce のメッセージをそのまま表示 |
| トークンエラー | 「接続が切れました」→ ポップアップ再接続案内 |

## Test plan

- [x] `npm run lint` — エラー 0件
- [x] `npm test` — 730件全 PASS（+20件）
- [x] pre-push フック通過
- [ ] 実機テスト: 「取引先を作って。ABC株式会社」で作成フロー確認

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)